### PR TITLE
Feature/tap only values methods

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,6 @@ Not all methods will make sense on Go and won't be implemented.
 - [ ] forPage
 - [x] get
 - [ ] groupBy
-- [ ] has
 - [ ] implode
 - [ ] intersect
 - [ ] intersectByKeys
@@ -63,7 +62,7 @@ Not all methods will make sense on Go and won't be implemented.
 - [ ] min
 - [ ] mode
 - [ ] nth
-- [ ] only
+- [x] only
 - [ ] pad
 - [ ] partition
 - [ ] pipe
@@ -107,7 +106,7 @@ Not all methods will make sense on Go and won't be implemented.
 - [ ] take
 - [ ] takeUntil
 - [ ] takeWhile
-- [ ] tap
+- [x] tap
 - [ ] times
 - [x] toArray (ToSlice)
 - [ ] toJson

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -147,16 +147,6 @@ func (c Collection[K, V]) Keys() []K {
 	return c.keys
 }
 
-func (c Collection[K, V]) Values() []V {
-	var values []V
-
-	c.Each(func(k K, v V) {
-		values = append(values, v)
-	})
-
-	return values
-}
-
 func (c Collection[K, V]) Sort(closure func(current, next V) bool) Collection[K, V] {
 	sort.Slice(c.keys, func(i, j int) bool {
 		return closure(c.values[c.keys[i]], c.values[c.keys[j]])

--- a/collection/collection.go
+++ b/collection/collection.go
@@ -127,6 +127,12 @@ func (c Collection[K, V]) Each(closure func(k K, v V)) Collection[K, V] {
 	return c
 }
 
+func (c Collection[K, V]) Tap(closure func(Collection[K, V])) Collection[K, V] {
+	closure(c)
+
+	return c
+}
+
 func (c Collection[K, V]) Search(value V) (K, error) {
 	for _, v := range c.keys {
 		if reflect.DeepEqual(c.values[v], value) {
@@ -139,6 +145,16 @@ func (c Collection[K, V]) Search(value V) (K, error) {
 
 func (c Collection[K, V]) Keys() []K {
 	return c.keys
+}
+
+func (c Collection[K, V]) Values() []V {
+	var values []V
+
+	c.Each(func(k K, v V) {
+		values = append(values, v)
+	})
+
+	return values
 }
 
 func (c Collection[K, V]) Sort(closure func(current, next V) bool) Collection[K, V] {
@@ -157,6 +173,19 @@ func (c Collection[K, V]) Map(closure func(k K, v V) V) Collection[K, V] {
 	})
 
 	return CollectMap(mappedValues)
+}
+
+func (c Collection[K, V]) Only(keys []K) Collection[K, V] {
+	onlyValues := make(map[K]V)
+
+	for _, key := range keys {
+		value, err := c.Get(key)
+		if err == nil {
+			onlyValues[key] = value
+		}
+	}
+
+	return CollectMap(onlyValues)
 }
 
 func (c Collection[K, V]) First() V {

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -97,6 +97,21 @@ func TestEachMethod(t *testing.T) {
 	}
 }
 
+func TestTap(t *testing.T) {
+	collectionSize := 3
+	collection := CollectMap(map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"})
+
+	collection.Tap(func(c Collection[string, string]) {
+		if c.IsEmpty() {
+			t.Error("The method not receive the correct collection!")
+		}
+
+		if c.Count() != collectionSize {
+			t.Error("The method not receive the correct collection!")
+		}
+	})
+}
+
 func TestSearchMethod(t *testing.T) {
 	items := map[string]any{"foo": "foo", "int": 1, "float": 1.0}
 	collection := CollectMap(items)
@@ -132,6 +147,17 @@ func TestKeys(t *testing.T) {
 	}
 }
 
+func TestValues(t *testing.T) {
+	collection := CollectMap(map[string]int{"foo": 123, "bar": 456, "baz": 789})
+	expectedValues := []int{123, 456, 789}
+
+	values := collection.Values()
+
+	if !reflect.DeepEqual(values, expectedValues) {
+		t.Errorf("expected %v. Got %v", expectedValues, values)
+	}
+}
+
 func TestSort(t *testing.T) {
 	collection := Collect(3, 2, 1)
 
@@ -164,6 +190,29 @@ func TestMap(t *testing.T) {
 			t.Error("Expected all values to be even!")
 		}
 	})
+}
+
+func TestOnly(t *testing.T) {
+	collection := CollectMap(map[string]int{"foo": 123, "bar": 456, "baz": 789})
+	expectedNewCollection := CollectMap(map[string]int{"foo": 123, "bar": 456})
+	keys := []string{"foo", "bar"}
+
+	newCollection := collection.Only(keys)
+
+	if !reflect.DeepEqual(newCollection, expectedNewCollection) {
+		t.Errorf("expected %v. Got %v", expectedNewCollection, newCollection)
+	}
+}
+
+func TestOnlyWithInvalidKeys(t *testing.T) {
+	collection := CollectMap(map[string]int{"foo": 123, "bar": 456, "baz": 789})
+	keys := []string{"fo", "ar"}
+
+	newCollection := collection.Only(keys)
+
+	if newCollection.Count() != 0 {
+		t.Error("The collection should be empty")
+	}
 }
 
 func TestFirst(t *testing.T) {
@@ -407,11 +456,11 @@ func TestCombine(t *testing.T) {
 	}
 
 	if len(combined.keys) != len(combined.values) {
-		t.Error("combined.keys should have the same lenght as combined.values")
+		t.Error("combined.keys should have the same length as combined.values")
 	}
 }
 
-func TestCombineDiffKeyLenghts(t *testing.T) {
+func TestCombineDiffKeyLengths(t *testing.T) {
 	keys := makeCollection[string, string](2)
 	keys.Put("0", "first_name")
 
@@ -504,7 +553,7 @@ func TestConcatWithIntKeys(t *testing.T) {
 	}
 }
 
-func TestCointainsKey(t *testing.T) {
+func TestContainsKey(t *testing.T) {
 	collection := CollectMap(map[string]string{"foo": "a", "bar": "b"})
 
 	if !collection.Contains(KeyEquals("foo")) {
@@ -512,7 +561,7 @@ func TestCointainsKey(t *testing.T) {
 	}
 }
 
-func TestCointainsValue(t *testing.T) {
+func TestContainsValue(t *testing.T) {
 	collection := CollectMap(map[string]string{"foo": "a", "bar": "b"})
 
 	if !collection.Contains(ValueEquals("a")) {

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -101,7 +101,7 @@ func TestTap(t *testing.T) {
 	collection := CollectMap(map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"})
 
 	collection.Tap(func(c Collection[string, string]) {
-		if !reflect.DeepEqual(collection, c) {
+		if c.Count() != collection.Count() {
 			t.Error("The collections are not equal")
 		}
 	})

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -147,17 +147,6 @@ func TestKeys(t *testing.T) {
 	}
 }
 
-func TestValues(t *testing.T) {
-	collection := CollectMap(map[string]int{"foo": 123, "bar": 456, "baz": 789})
-	expectedValues := []int{123, 456, 789}
-
-	values := collection.Values()
-
-	if !reflect.DeepEqual(values, expectedValues) {
-		t.Errorf("expected %v. Got %v", expectedValues, values)
-	}
-}
-
 func TestSort(t *testing.T) {
 	collection := Collect(3, 2, 1)
 

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -183,7 +183,7 @@ func TestOnly(t *testing.T) {
 
 	newCollection := collection.Only(keys)
 
-	if !reflect.DeepEqual(newCollection, expectedNewCollection) {
+	if !reflect.DeepEqual(newCollection.values, expectedNewCollection.values) {
 		t.Errorf("expected %v. Got %v", expectedNewCollection, newCollection)
 	}
 }

--- a/collection/collection_test.go
+++ b/collection/collection_test.go
@@ -98,16 +98,11 @@ func TestEachMethod(t *testing.T) {
 }
 
 func TestTap(t *testing.T) {
-	collectionSize := 3
 	collection := CollectMap(map[string]string{"foo": "foo", "bar": "bar", "baz": "baz"})
 
 	collection.Tap(func(c Collection[string, string]) {
-		if c.IsEmpty() {
-			t.Error("The method not receive the correct collection!")
-		}
-
-		if c.Count() != collectionSize {
-			t.Error("The method not receive the correct collection!")
+		if !reflect.DeepEqual(collection, c) {
+			t.Error("The collections are not equal")
 		}
 	})
 }


### PR DESCRIPTION
This PR adds `only` and `tap` methods and removes `has` from the TODO list because already exists `contains` method that does the same thing