### PR TITLE
Split generic and numeric files and add new funcs

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -40,6 +40,12 @@ func NewEmptyCollectionError(cause ...error) error {
 	return wrap("empty collection", nil, cause)
 }
 
+type IntexOutOfBoundsError error
+
+func NewIndexOutOfBoundsError(cause ...error) error {
+	return wrap("index out of bounds", nil, cause)
+}
+
 func wrap(format string, args []any, cause []error) error {
 	msg := fmt.Sprintf(format, args...)
 

--- a/generic.go
+++ b/generic.go
@@ -1,0 +1,122 @@
+package collections
+
+import (
+	"reflect"
+	"sort"
+
+	"github.com/thefuga/go-collections/errors"
+)
+
+func Get[T any](i int, slice []T) T {
+	v, _ := GetE(i, slice)
+	return v
+}
+
+func GetE[T any](i int, slice []T) (T, error) {
+	if len(slice) == 0 {
+		return *new(T), errors.NewEmptyCollectionError(
+			errors.NewValueNotFoundError(),
+		)
+	}
+
+	if i < 0 || len(slice) <= i {
+		return *new(T), errors.NewIndexOutOfBoundsError(
+			errors.NewValueNotFoundError(),
+		)
+	}
+
+	return slice[i], nil
+}
+
+func First[T any](slice []T) (T, error) {
+	return GetE(0, slice)
+}
+
+func Push[T any](v T, slice []T) []T {
+	return append(slice, v)
+}
+
+func Put[T any](i int, v T, slice []T) []T {
+	if len(slice) == 0 {
+		slice = make([]T, i+1)
+		slice[i] = v
+		return slice
+	}
+
+	if cap(slice) < len(slice)+1 {
+		newSlice := make([]T, 0, len(slice)+1)
+		slice = append(newSlice, slice...)
+	}
+
+	slice = append(slice[:i+1], slice[i:]...)
+	slice[i] = v
+	return slice
+}
+
+func Pop[T any](slice *[]T) T {
+	v, _ := PopE(slice)
+	return v
+}
+
+func PopE[T any](slice *[]T) (T, error) {
+	v, err := LastE(*slice)
+
+	if err != nil {
+		return v, err
+	}
+
+	*slice = (*slice)[:len(*slice)-1]
+
+	return v, nil
+}
+
+func Last[T any](slice []T) T {
+	v, _ := GetE(len(slice)-1, slice)
+	return v
+}
+
+func LastE[T any](slice []T) (T, error) {
+	return GetE(len(slice)-1, slice)
+}
+
+func Each[T any](f func(i int, v T), slice []T) {
+	for i, v := range slice {
+		f(i, v)
+	}
+}
+
+func Search[T any](v T, slice []T) (int, error) {
+	for i := range slice {
+		if reflect.DeepEqual(slice[i], v) {
+			return i, nil
+		}
+	}
+
+	return -1, errors.NewValueNotFoundError()
+}
+
+func Map[T any](f func(i int, v T) T, slice []T) []T {
+	mappedValues := make([]T, 0, len(slice))
+
+	Each(func(_ int, v T) {
+		mappedValues = Push(v, mappedValues)
+	}, slice)
+
+	return mappedValues
+}
+
+func Sort[T any](slice []T, f func(current, next T) bool) {
+	sort.Slice(slice, func(i, j int) bool {
+		return f(slice[i], slice[j])
+	})
+}
+
+func Sum[T Number](slice []T) T {
+	var sum T
+
+	for _, v := range slice {
+		sum += v
+	}
+
+	return sum
+}

--- a/generic_test.go
+++ b/generic_test.go
@@ -1,0 +1,369 @@
+package collections
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	testCases := []struct {
+		description string
+		sut         []int
+		i           int
+		v           int
+		err         error
+	}{
+		{
+			"calling Get with empty slice",
+			[]int{},
+			0,
+			0,
+			fmt.Errorf("value not found: empty collection"),
+		},
+		{
+			"calling Get with out of bounds index",
+			[]int{1},
+			2,
+			0,
+			fmt.Errorf("value not found: index out of bounds"),
+		},
+		{
+			"calling Get with slice with values",
+			[]int{1, 2, 3, 4},
+			0,
+			1,
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			getV := Get(tc.i, tc.sut)
+			getEV, err := GetE(tc.i, tc.sut)
+
+			if tc.v != getV || tc.v != getEV {
+				t.Errorf("expected get values to be %d and %d. got %d", getV, getEV, tc.v)
+			}
+
+			if tc.err != nil {
+				if err == nil || err.Error() != tc.err.Error() {
+					t.Errorf("expect error to be '%s'. got '%s'", tc.err.Error(), err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestPush(t *testing.T) {
+	expectedPushed := []int{1}
+	var sut []int
+
+	if pushed := Push(1, sut); !reflect.DeepEqual(pushed, expectedPushed) {
+		t.Errorf("expected slice after push to be %v. got %v", expectedPushed, pushed)
+	}
+}
+
+func TestPut(t *testing.T) {
+	testCases := []struct {
+		description string
+		sut         []string
+		i           int
+		v           string
+		expectation []string
+	}{
+		{
+			"putting at 0 on empty slice",
+			[]string{},
+			0,
+			"foo",
+			[]string{"foo"},
+		},
+		{
+			"putting at 1 on an empty slice",
+			[]string{},
+			1,
+			"foo",
+			[]string{"", "foo"},
+		},
+		{
+			"putting in the middle of a slice",
+			[]string{"foo", "baz", "foo", "bar", "baz"},
+			1,
+			"bar",
+			[]string{"foo", "bar", "baz", "foo", "bar", "baz"},
+		},
+		{
+			"prepending to a slice",
+			[]string{"bar", "baz"},
+			0,
+			"foo",
+			[]string{"foo", "bar", "baz"},
+		},
+		{
+			"appending to a slice",
+			[]string{"foo", "bar"},
+			2,
+			"baz",
+			[]string{"foo", "bar", "baz"},
+		},
+		{
+			"appending to a high cap slice",
+			append(make([]string, 0, 10), "foo", "baz"),
+			1,
+			"bar",
+			append(make([]string, 0, 10), "foo", "bar", "baz"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actual := Put(tc.i, tc.v, tc.sut)
+
+			if !reflect.DeepEqual(actual, tc.expectation) {
+				t.Errorf("expected %v. got %v", tc.expectation, actual)
+			}
+
+			if len(actual) != len(tc.expectation) {
+				t.Errorf("expected %d. got %d", len(tc.expectation), len(actual))
+			}
+
+			if cap(actual) != cap(tc.expectation) {
+				t.Errorf("expected %d. got %d", cap(tc.expectation), cap(actual))
+			}
+		})
+	}
+}
+
+func TestPop(t *testing.T) {
+	testCases := []struct {
+		description string
+		sut         []string
+		v           string
+		err         error
+		count       int
+		capacity    int
+	}{
+		{
+			"popping an empty slice",
+			[]string{},
+			"",
+			fmt.Errorf("value not found: empty collection"),
+			0,
+			0,
+		},
+		{
+			"popping a slice with items",
+			[]string{"foo", "bar"},
+			"bar",
+			nil,
+			1,
+			2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actualV, actualErr := PopE(&tc.sut)
+
+			if actualV != tc.v {
+				t.Errorf("expected %s. got %s", tc.v, actualV)
+			}
+
+			if actualErr != nil && tc.err != nil {
+				if actualErr.Error() != tc.err.Error() {
+					t.Errorf("expected '%s'. got '%s'", tc.err.Error(), actualErr.Error())
+				}
+			}
+
+			if len(tc.sut) != tc.count {
+				t.Errorf("expected count after poping to be %d. got %d", tc.count, len(tc.sut))
+			}
+
+			if cap(tc.sut) != tc.capacity {
+				t.Errorf("expected capacity after poping to be %d. got %d", tc.capacity, cap(tc.sut))
+			}
+		})
+	}
+}
+
+func TestEach(t *testing.T) {
+	var eachResult []any
+	sut := []any{1, "foo", 1.1}
+
+	Each(func(_ int, v any) {
+		eachResult = append(eachResult, v)
+	}, sut)
+
+	if !reflect.DeepEqual(eachResult, sut) {
+		t.Errorf("expected visited values to be %v. got %v", sut, eachResult)
+	}
+}
+
+func TestSearch(t *testing.T) {
+	testCases := []struct {
+		description string
+		sut         []any
+		input       any
+		i           int
+		err         error
+	}{
+		{
+			"searching with an empty slice",
+			[]any{},
+			"foo",
+			-1,
+			fmt.Errorf("value not found"),
+		},
+		{
+			"searching an unexisting element",
+			[]any{1, "foo", 1.0},
+			"bar",
+			-1,
+			fmt.Errorf("value not found"),
+		},
+		{
+			"searching an existing element",
+			[]any{1, "foo", 1.0},
+			"foo",
+			1,
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			i, err := Search(tc.input, tc.sut)
+
+			if i != tc.i {
+				t.Errorf("expected resulting index to be %d. got %d", tc.i, i)
+			}
+
+			if err != nil {
+				if err.Error() != tc.err.Error() {
+					t.Errorf("expected error '%s'. got '%s'", tc.err.Error(), err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestSort(t *testing.T) {
+	sut := []int{3, 2, 4, 1}
+	sorted := []int{1, 2, 3, 4}
+
+	Sort(sut, Asc[int]())
+
+	if !reflect.DeepEqual(sut, sorted) {
+		t.Errorf("expected sorted slice to be %v. got %v", sorted, sut)
+	}
+}
+
+func TestMap(t *testing.T) {
+	testCases := []struct {
+		description      string
+		sut              []int
+		mappedCollection []int
+	}{
+		{
+			"mapping an empty slice",
+			[]int{},
+			[]int{},
+		},
+		{
+			"mapping a slice with values",
+			[]int{1, 2, 3},
+			[]int{2, 3, 4},
+		},
+	}
+
+	f := func(_ int, v int) int {
+		return v + 1
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			mappedCollection := Map(f, tc.sut)
+
+			if !reflect.DeepEqual(mappedCollection, tc.sut) {
+				t.Errorf("expected mapped collection to be %v. got %v", tc.mappedCollection, mappedCollection)
+			}
+		})
+	}
+}
+
+func TestFirst(t *testing.T) {
+	testCases := []struct {
+		description string
+		sut         []string
+		v           string
+		err         error
+	}{
+		{
+			"calling First with an empty slice",
+			[]string{},
+			"",
+			fmt.Errorf("value not found: empty collection"),
+		},
+		{
+			"calling first with a slice with values",
+			[]string{"foo", "bar", "baz"},
+			"foo",
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			v, err := First(tc.sut)
+
+			if v != tc.v {
+				t.Errorf("expected returned value to be '%s', got '%s'", tc.v, v)
+			}
+
+			if err != nil && tc.err != nil {
+				if err.Error() != tc.err.Error() {
+					t.Errorf("expected error '%s'. got '%s'", tc.err.Error(), err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestLast(t *testing.T) {
+	testCases := []struct {
+		description string
+		sut         []string
+		v           string
+		err         error
+	}{
+		{
+			"calling Last with an empty slice",
+			[]string{},
+			"",
+			fmt.Errorf("value not found: empty collection"),
+		},
+		{
+			"calling last with a slice with values",
+			[]string{"foo", "bar", "baz"},
+			"baz",
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			v, err := LastE(tc.sut)
+
+			if v != tc.v {
+				t.Errorf("expected returned value to be '%s', got '%s'", tc.v, v)
+			}
+
+			if err != nil && tc.err != nil {
+				if err.Error() != tc.err.Error() {
+					t.Errorf("expected error '%s'. got '%s'", tc.err.Error(), err.Error())
+				}
+			}
+		})
+	}
+}

--- a/generic_test.go
+++ b/generic_test.go
@@ -140,6 +140,49 @@ func TestPop(t *testing.T) {
 		description string
 		sut         []string
 		v           string
+		count       int
+		capacity    int
+	}{
+		{
+			"popping an empty slice",
+			[]string{},
+			"",
+			0,
+			0,
+		},
+		{
+			"popping a slice with items",
+			[]string{"foo", "bar"},
+			"bar",
+			1,
+			2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actualV := Pop(&tc.sut)
+
+			if actualV != tc.v {
+				t.Errorf("expected %s. got %s", tc.v, actualV)
+			}
+
+			if len(tc.sut) != tc.count {
+				t.Errorf("expected count after poping to be %d. got %d", tc.count, len(tc.sut))
+			}
+
+			if cap(tc.sut) != tc.capacity {
+				t.Errorf("expected capacity after poping to be %d. got %d", tc.capacity, cap(tc.sut))
+			}
+		})
+	}
+}
+
+func TestPopE(t *testing.T) {
+	testCases := []struct {
+		description string
+		sut         []string
+		v           string
 		err         error
 		count       int
 		capacity    int
@@ -331,6 +374,35 @@ func TestFirst(t *testing.T) {
 }
 
 func TestLast(t *testing.T) {
+	testCases := []struct {
+		description string
+		sut         []string
+		v           string
+	}{
+		{
+			"calling Last with an empty slice",
+			[]string{},
+			"",
+		},
+		{
+			"calling last with a slice with values",
+			[]string{"foo", "bar", "baz"},
+			"baz",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			v := Last(tc.sut)
+
+			if v != tc.v {
+				t.Errorf("expected returned value to be '%s', got '%s'", tc.v, v)
+			}
+		})
+	}
+}
+
+func TestLastE(t *testing.T) {
 	testCases := []struct {
 		description string
 		sut         []string

--- a/numeric.go
+++ b/numeric.go
@@ -1,20 +1,8 @@
 package collections
 
 import (
-	"sort"
-
 	"github.com/thefuga/go-collections/errors"
 )
-
-func Sum[T Number](slice []T) T {
-	var sum T
-
-	for _, v := range slice {
-		sum += v
-	}
-
-	return sum
-}
 
 func AverageE[T Number](slice []T) (T, error) {
 	if len(slice) == 0 {
@@ -27,14 +15,6 @@ func AverageE[T Number](slice []T) (T, error) {
 func Average[T Number](slice []T) T {
 	avg, _ := AverageE(slice)
 	return avg
-}
-
-func First[T Number](slice []T) (T, error) {
-	if len(slice) == 0 {
-		return *new(T), errors.NewEmptyCollectionError()
-	}
-
-	return slice[0], nil
 }
 
 func MinE[T Number](slice []T) (T, error) {
@@ -88,10 +68,4 @@ func Median[T Number](slice []T) float64 {
 	}
 
 	return float64(slice[halfway])
-}
-
-func Sort[T Number](slice []T, f func(current, next T) bool) {
-	sort.Slice(slice, func(i, j int) bool {
-		return f(slice[i], slice[j])
-	})
 }

--- a/numeric_test.go
+++ b/numeric_test.go
@@ -1,8 +1,6 @@
 package collections
 
 import (
-	"fmt"
-	"reflect"
 	"testing"
 )
 
@@ -62,44 +60,6 @@ func TestAverage(t *testing.T) {
 	}
 }
 
-func TestFirst(t *testing.T) {
-	testCases := []struct {
-		description string
-		sut         []int
-		v           int
-		err         error
-	}{
-		{
-			"calling first with empty slice",
-			[]int{},
-			0,
-			fmt.Errorf("empty collection"),
-		},
-		{
-			"calling first with slice with values",
-			[]int{1, 2, 3, 4},
-			1,
-			nil,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			v, err := First(tc.sut)
-
-			if v != tc.v {
-				t.Errorf("expected first value to be %d. got %d", tc.v, v)
-			}
-
-			if err != nil {
-				if err.Error() != tc.err.Error() {
-					t.Errorf("expected error '%s'. got %s", tc.err.Error(), err.Error())
-				}
-			}
-		})
-	}
-}
-
 func TestMin(t *testing.T) {
 	testCases := []struct {
 		description string
@@ -151,17 +111,6 @@ func TestMax(t *testing.T) {
 				t.Errorf("expected max value to be %d. got %d", tc.max, max)
 			}
 		})
-	}
-}
-
-func TestSort(t *testing.T) {
-	sut := []int{3, 2, 4, 1}
-	sorted := []int{1, 2, 3, 4}
-
-	Sort(sut, Asc[int]())
-
-	if !reflect.DeepEqual(sut, sorted) {
-		t.Errorf("expected sorted slice to be %v. got %v", sorted, sut)
 	}
 }
 


### PR DESCRIPTION
# What?
Splits the numeric and generic function to different files and add some new generic funcs.
# Why?
To improve organization and allow for further refactorings to reuse these funcs.
# How?
Everything was based on existing code, essentially replacing the generic collection receiver with a slice.
