### PR TITLE
feat(generic): add `Interpose`

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -489,13 +489,11 @@ func Interpose[V any](slice []V, sep V) []V {
 
 	resultLen := len(slice)*2 - 1
 	result := make([]V, resultLen)
+	result[resultLen-1] = slice[len(slice)-1]
 
-	for i, v := range slice {
-		result[i*2] = v
-	}
-
-	for i := 1; i < resultLen; i = i + 2 {
-		result[i] = sep
+	for i := 0; i+1 < len(slice); i++ {
+		result[i*2] = slice[i]
+		result[i*2+1] = sep
 	}
 
 	return result

--- a/generic.go
+++ b/generic.go
@@ -481,6 +481,7 @@ func Range[T Integer](min, max T) []T {
 	return result
 }
 
+// Interpose adds `sep` between every element in `slice`
 func Interpose[V any](slice []V, sep V) []V {
 	if len(slice) == 0 {
 		return slice

--- a/generic.go
+++ b/generic.go
@@ -480,3 +480,22 @@ func Range[T Integer](min, max T) []T {
 	}
 	return result
 }
+
+func Interpose[V any](slice []V, sep V) []V {
+	if len(slice) == 0 {
+		return slice
+	}
+
+	resultLen := len(slice)*2 - 1
+	result := make([]V, resultLen)
+
+	for i, v := range slice {
+		result[i*2] = v
+	}
+
+	for i := 1; i < resultLen; i = i + 2 {
+		result[i] = sep
+	}
+
+	return result
+}

--- a/generic_test.go
+++ b/generic_test.go
@@ -1711,3 +1711,51 @@ func TestRange(t *testing.T) {
 		})
 	}
 }
+
+func TestInterpose(t *testing.T) {
+	testCases := []struct {
+		name     string
+		slice    []string
+		sep      string
+		expected []string
+	}{
+		{
+			name:     "with even slice length",
+			slice:    []string{"1", "2", "3", "4"},
+			sep:      ",",
+			expected: []string{"1", ",", "2", ",", "3", ",", "4"},
+		},
+		{
+			name:     "with odd slice length",
+			slice:    []string{"1", "2", "3"},
+			sep:      ",",
+			expected: []string{"1", ",", "2", ",", "3"},
+		},
+		{
+			name:     "empty slice",
+			slice:    []string{},
+			sep:      ",",
+			expected: []string{},
+		},
+		{
+			name:     "one element",
+			slice:    []string{"a"},
+			sep:      ",",
+			expected: []string{"a"},
+		},
+		{
+			name:     "two elements",
+			slice:    []string{"a", "b"},
+			sep:      ",",
+			expected: []string{"a", ",", "b"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Interpose(tc.slice, tc.sep); !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("Expected '%v'. Got '%v'", tc.expected, got)
+			}
+		})
+	}
+}

--- a/tests/benchmark/generic/interpose_test.go
+++ b/tests/benchmark/generic/interpose_test.go
@@ -1,0 +1,16 @@
+package generic
+
+import (
+	"testing"
+
+	. "github.com/thefuga/go-collections"
+	"github.com/thefuga/go-collections/tests/benchmark"
+)
+
+func BenchmarkInterpose(b *testing.B) {
+	slice := benchmark.BuildIntSlice()
+
+	for n := 0; n < b.N; n++ {
+		Interpose(slice, 0)
+	}
+}


### PR DESCRIPTION
# What?
add `Interpose`
https://clojuredocs.org/clojure.core/interpose
# Why?
It's pretty useful
# How?
spreading elements from `slice` into the even indices and setting every odd index to `sep`