### PR TITLE
refactor(matcher): add a more constrained version of the Matcher type

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -270,7 +270,7 @@ func Mode[T comparable](slice []T) []T {
 }
 
 // Contains checks if the slice holds at least one value matching the given matcher.
-func Contains[V any](slice []V, matcher Matcher) bool {
+func Contains[V any](slice []V, matcher AnyMatcher) bool {
 	for i, v := range slice {
 		if matcher(i, v) {
 			return true
@@ -281,14 +281,14 @@ func Contains[V any](slice []V, matcher Matcher) bool {
 }
 
 // FirstWhere uses FirstWhereE, omitting the error.
-func FirstWhere[V any](slice []V, matcher Matcher) V {
+func FirstWhere[V any](slice []V, matcher AnyMatcher) V {
 	v, _ := FirstWhereE(slice, matcher)
 	return v
 }
 
 // FirstWhereE returns the first value matched by the given matcher. Should no value
 // match, an instance of errors.ValueNotFoundError is returned.
-func FirstWhereE[V any](slice []V, matcher Matcher) (V, error) {
+func FirstWhereE[V any](slice []V, matcher AnyMatcher) (V, error) {
 	for i, v := range slice {
 		if matcher(i, v) {
 			return v, nil
@@ -299,7 +299,7 @@ func FirstWhereE[V any](slice []V, matcher Matcher) (V, error) {
 }
 
 // FirstWhereField uses FirstWhereFieldE, omitting the error.
-func FirstWhereField[V any](slice []V, field string, matcher Matcher) V {
+func FirstWhereField[V any](slice []V, field string, matcher AnyMatcher) V {
 	v, _ := FirstWhereFieldE(slice, field, matcher)
 	return v
 }
@@ -308,7 +308,7 @@ func FirstWhereField[V any](slice []V, field string, matcher Matcher) V {
 // on S.
 // Should either no element match, the field doesn't exist on the struct V, or V is not
 // a struct, an instance of errors.ValueNotFoundError is returned.
-func FirstWhereFieldE[V any](slice []V, field string, matcher Matcher) (V, error) {
+func FirstWhereFieldE[V any](slice []V, field string, matcher AnyMatcher) (V, error) {
 	for i, v := range slice {
 		if FieldMatch[V](field, matcher)(i, v) {
 			return v, nil

--- a/generic_test.go
+++ b/generic_test.go
@@ -895,7 +895,7 @@ func TestFirstWhereField(t *testing.T) {
 		description string
 		sut         []user
 		field       string
-		matcher     Matcher
+		matcher     AnyMatcher
 		user        user
 	}{
 		{
@@ -935,7 +935,7 @@ func TestFirstWhereFieldE(t *testing.T) {
 		description string
 		sut         []user
 		field       string
-		matcher     Matcher
+		matcher     AnyMatcher
 		user        user
 		err         error
 	}{
@@ -988,7 +988,7 @@ func TestFirstWhereE(t *testing.T) {
 	testCases := []struct {
 		description string
 		sut         []int
-		matcher     Matcher
+		matcher     AnyMatcher
 		v           int
 		err         error
 	}{
@@ -1037,7 +1037,7 @@ func TestFirstWhereWithComposedMatchers(t *testing.T) {
 		description string
 		sut         []user
 		field       string
-		matcher     Matcher
+		matcher     AnyMatcher
 		user        user
 		err         error
 	}{
@@ -1090,7 +1090,7 @@ func TestFirstWhere(t *testing.T) {
 	testCases := []struct {
 		description string
 		sut         []int
-		matcher     Matcher
+		matcher     AnyMatcher
 		v           int
 	}{
 		{
@@ -1120,7 +1120,7 @@ func TestContains(t *testing.T) {
 	testCases := []struct {
 		description string
 		slice       []int
-		matcher     Matcher
+		matcher     AnyMatcher
 		contains    bool
 	}{
 		{

--- a/kv/collection.go
+++ b/kv/collection.go
@@ -239,12 +239,12 @@ func (c Collection[K, V]) Concat(concatTo Collection[K, V]) Collection[K, V] {
 }
 
 // Contains checks if any values on the Collection match f.
-func (c Collection[K, V]) Contains(f collections.Matcher) bool {
+func (c Collection[K, V]) Contains(f collections.AnyMatcher) bool {
 	return c.Values().Contains(f)
 }
 
 // Every checks if every value on the Collection match f.
-func (c Collection[K, V]) Every(f collections.Matcher) bool {
+func (c Collection[K, V]) Every(f collections.AnyMatcher) bool {
 	for k, v := range c {
 		if !f(k, v) {
 			return false

--- a/kv/ordered/collection.go
+++ b/kv/ordered/collection.go
@@ -234,7 +234,7 @@ func (c Collection[K, V]) FirstE() (V, error) {
 
 // FirstOrFail returns the key-value pair of the first occurrence matched by f.
 // Should no entry match, an instance of NewValueNotFoundError is returned.
-func (c Collection[K, V]) FirstOrFail(f collections.Matcher) (K, V, error) {
+func (c Collection[K, V]) FirstOrFail(f collections.AnyMatcher) (K, V, error) {
 	var (
 		found bool
 		v     V
@@ -340,13 +340,13 @@ func (c Collection[K, V]) Concat(concatTo Collection[K, V]) Collection[K, V] {
 }
 
 // Contains checks if any values on the Collection match f.
-func (c Collection[K, V]) Contains(f collections.Matcher) bool {
+func (c Collection[K, V]) Contains(f collections.AnyMatcher) bool {
 	_, _, err := c.FirstOrFail(f)
 	return err == nil
 }
 
 // Every checks if every value on the Collection match f.
-func (c Collection[K, V]) Every(f collections.Matcher) bool {
+func (c Collection[K, V]) Every(f collections.AnyMatcher) bool {
 	contains := true
 
 	c.Each(func(k K, v V) {

--- a/matcher.go
+++ b/matcher.go
@@ -2,13 +2,14 @@ package collections
 
 import "reflect"
 
-// Matcher is used by matchers on functions that  must compare keys and values from
+// AnyMatcher is used by matchers on functions that  must compare keys and values from
 // a collection.
 // It is used as a functional option. To learn more, see: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
-type Matcher func(key any, value any) bool
+type Matcher[K any, V any] func(key K, value V) bool
+type AnyMatcher = Matcher[any, any]
 
 // KeyEquals builds a matcher to compare the given key to the key passed by the matcher caller.
-func KeyEquals(key any) Matcher {
+func KeyEquals(key any) AnyMatcher {
 	return func(collectionKey any, _ any) bool {
 		return key == collectionKey
 	}
@@ -16,7 +17,7 @@ func KeyEquals(key any) Matcher {
 
 // ValueEquals builds a matcher to compare the given value (with reflect.DeepEqual)
 // to the value passed by the matcher caller.
-func ValueEquals(value any) Matcher {
+func ValueEquals(value any) AnyMatcher {
 	return func(_ any, collectionValue any) bool {
 		return reflect.DeepEqual(value, collectionValue)
 	}
@@ -24,7 +25,7 @@ func ValueEquals(value any) Matcher {
 
 // ValueDiffers builds a matcher to compare the given value (with reflect.DeepEqual)
 // to the value passed by the matcher caller. It has the opposite behavior from ValueEquals
-func ValueDiffers(value any) Matcher {
+func ValueDiffers(value any) AnyMatcher {
 	return func(_ any, collectionValue any) bool {
 		return !reflect.DeepEqual(value, collectionValue)
 	}
@@ -32,7 +33,7 @@ func ValueDiffers(value any) Matcher {
 
 // ValueGT compares the given numeric value to check if it is greater than the value
 // given by the matcher's caller.
-func ValueGT[T Number](value T) Matcher {
+func ValueGT[T Number](value T) AnyMatcher {
 	return func(_ any, collectionValue any) bool {
 		if cast, ok := collectionValue.(T); ok {
 			return value < cast
@@ -43,7 +44,7 @@ func ValueGT[T Number](value T) Matcher {
 
 // ValueLT compares the given numeric value to check if it is lesser than the value
 // given by the matcher's caller.
-func ValueLT[T Number](value T) Matcher {
+func ValueLT[T Number](value T) AnyMatcher {
 	return func(_ any, collectionValue any) bool {
 		if cast, ok := collectionValue.(T); ok {
 			return value > cast
@@ -53,14 +54,14 @@ func ValueLT[T Number](value T) Matcher {
 }
 
 // FieldEquals uses FieldMatch composed with ValueEquals as the matcher.
-func FieldEquals[V any](field string, value any) Matcher {
+func FieldEquals[V any](field string, value any) AnyMatcher {
 	return FieldMatch[V](field, ValueEquals(value))
 }
 
 // FieldMatch will attempt to retrieve the value corresponding to the given struct
 // field name. V must be a struct, otherwise calls to the matcher will always return false.
 // The retrieved value will be used to supply the given matcher.
-func FieldMatch[V any](field string, matcher Matcher) Matcher {
+func FieldMatch[V any](field string, matcher AnyMatcher) AnyMatcher {
 	return func(_, v any) bool {
 		cast, ok := v.(V)
 		if !ok {
@@ -83,7 +84,7 @@ func FieldMatch[V any](field string, matcher Matcher) Matcher {
 
 // And combines all the given matchers into a single matcher which returns true
 // when all matchers return true.
-func And[V any](matchers ...Matcher) Matcher {
+func And[V any](matchers ...AnyMatcher) AnyMatcher {
 	return func(i any, collectionValue any) bool {
 		match := true
 
@@ -99,7 +100,7 @@ func And[V any](matchers ...Matcher) Matcher {
 // will receive v. It is useful to compare build matchers dynamically at the execution time
 // rather than at the function's call time (i.e. the composed matchers won't be called until
 // the higher order matcher is called).
-func AndValue[V any](v V, matchers ...func(V) Matcher) Matcher {
+func AndValue[V any](v V, matchers ...func(V) AnyMatcher) AnyMatcher {
 	return func(i any, collectionValue any) bool {
 		match := true
 
@@ -113,7 +114,7 @@ func AndValue[V any](v V, matchers ...func(V) Matcher) Matcher {
 
 // Or combines all the given matchers into a single matcher which returns true
 // when at least one of the given matcher returns true.
-func Or[V any](matchers ...Matcher) Matcher {
+func Or[V any](matchers ...AnyMatcher) AnyMatcher {
 	return func(i any, collectionValue any) bool {
 		match := true
 
@@ -129,7 +130,7 @@ func Or[V any](matchers ...Matcher) Matcher {
 // will receive v. It is useful to compare build matchers dynamically at the execution time
 // rather than at the function's call time (i.e. the composed matchers won't be called until
 // the higher order matcher is called).
-func OrValue[V any](v V, matchers ...func(V) Matcher) Matcher {
+func OrValue[V any](v V, matchers ...func(V) AnyMatcher) AnyMatcher {
 	return func(i any, collectionValue any) bool {
 		match := true
 

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -124,8 +124,8 @@ func TestAndValue(t *testing.T) {
 
 	if !AndValue(
 		11,
-		func(v int) Matcher { return ValueGT(-v) },
-		func(v int) Matcher { return ValueLT(v) },
+		func(v int) AnyMatcher { return ValueGT(-v) },
+		func(v int) AnyMatcher { return ValueLT(v) },
 	)(0, i) {
 		t.Error("10 is greater than -11 and lesser than 11")
 	}
@@ -144,8 +144,8 @@ func TestOrValue(t *testing.T) {
 
 	if !OrValue(
 		10,
-		func(v int) Matcher { return ValueGT(v) },
-		func(v int) Matcher { return ValueLT(2 * v) },
+		func(v int) AnyMatcher { return ValueGT(v) },
+		func(v int) AnyMatcher { return ValueLT(2 * v) },
 	)(0, i) {
 		t.Error("11 is greater than 10 and lesser than 20")
 	}

--- a/slice/collection.go
+++ b/slice/collection.go
@@ -18,7 +18,7 @@ func Collect[V any](values ...V) Collection[V] {
 }
 
 // Contains passes the collection and the given params to the generic Contains function.
-func (c Collection[V]) Contains(matcher collections.Matcher) bool {
+func (c Collection[V]) Contains(matcher collections.AnyMatcher) bool {
 	return collections.Contains(c, matcher)
 }
 

--- a/slice/collection_test.go
+++ b/slice/collection_test.go
@@ -536,7 +536,7 @@ func TestContains(t *testing.T) {
 	testCases := []struct {
 		description string
 		collection  Collection[int]
-		matcher     collections.Matcher
+		matcher     collections.AnyMatcher
 		contains    bool
 	}{
 		{

--- a/support_test.go
+++ b/support_test.go
@@ -6,7 +6,7 @@ type user struct {
 	Age   int
 }
 
-func usernameMatch(u user) Matcher {
+func usernameMatch(u user) AnyMatcher {
 	return func(_, v any) bool {
 		collectionUser, ok := v.(user)
 		if !ok {
@@ -17,7 +17,7 @@ func usernameMatch(u user) Matcher {
 	}
 }
 
-func ageMatch(u user) Matcher {
+func ageMatch(u user) AnyMatcher {
 	return func(_, v any) bool {
 		collectionUser, ok := v.(user)
 		if !ok {


### PR DESCRIPTION
# What?
introduce a more constrained version of `Matcher`
# Why?
This will allow us to be more specific when we can
# How?
By making `Matcher` generic and introducing `AnyMatcher`, which is basically the old `Matcher`
