### PR TITLE
feat(generic): add `ForPage`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 # TODO
+
 The list bellow is based on methods available on https://laravel.com/docs/9.x/collections#available-methods
 Not all methods will make sense on Go and won't be implemented.
+
 - [x] all (ToSlice)
 - [x] average
 - [x] avg (Average)
@@ -35,7 +37,7 @@ Not all methods will make sense on Go and won't be implemented.
 - [ ] flatten
 - [x] flip
 - [x] forget
-- [ ] forPage
+- [x] forPage
 - [x] get
 - [x] groupBy
 - [ ] implode
@@ -90,7 +92,7 @@ Not all methods will make sense on Go and won't be implemented.
 - [ ] skipWhile
 - [ ] sliding
 - [ ] sole
-- [x] sort 
+- [x] sort
 - [ ] sortBy
 - [ ] sortByDesc
 - [ ] sortDesc

--- a/generic.go
+++ b/generic.go
@@ -498,3 +498,15 @@ func Interpose[V any](slice []V, sep V) []V {
 
 	return result
 }
+
+// ForPage returns a slice containing the items that would be present on a given page number
+func ForPage[V any](slice []V, page, size int) []V {
+	lower, upper := (page-1)*size, (page-1)*size+size
+	if upper > len(slice) {
+		upper = len(slice)
+	}
+	if lower < 0 || lower > upper {
+		return []V{}
+	}
+	return slice[lower:upper]
+}

--- a/generic_test.go
+++ b/generic_test.go
@@ -1759,3 +1759,71 @@ func TestInterpose(t *testing.T) {
 		})
 	}
 }
+
+func TestForPage(t *testing.T) {
+	testCases := []struct {
+		name     string
+		slice    []int
+		page     int
+		size     int
+		expected []int
+	}{
+		{
+			name:     "1 through 9, page 1 with size 3",
+			slice:    []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			page:     1,
+			size:     3,
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "1 through 9, page 2 with size 3",
+			slice:    []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			page:     2,
+			size:     3,
+			expected: []int{4, 5, 6},
+		},
+		{
+			name:     "1 through 9, page 3 with size 3",
+			slice:    []int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			page:     3,
+			size:     3,
+			expected: []int{7, 8, 9},
+		},
+		{
+			name:     "page = 0",
+			slice:    []int{1, 2, 3},
+			page:     0,
+			size:     3,
+			expected: []int{},
+		},
+		{
+			name:     "page * size > len(slice)",
+			slice:    []int{1, 2, 3},
+			page:     2,
+			size:     3,
+			expected: []int{},
+		},
+		{
+			name:     "size = len(slice)",
+			slice:    []int{1, 2, 3},
+			page:     1,
+			size:     3,
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "size > len(slice)",
+			slice:    []int{1, 2, 3},
+			page:     1,
+			size:     10,
+			expected: []int{1, 2, 3},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ForPage(tc.slice, tc.page, tc.size); !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("Expected '%v'. Got '%v'", tc.expected, got)
+			}
+		})
+	}
+}

--- a/tests/benchmark/generic/for_page_test.go
+++ b/tests/benchmark/generic/for_page_test.go
@@ -1,0 +1,17 @@
+package generic
+
+import (
+	"testing"
+
+	"github.com/thefuga/go-collections"
+	"github.com/thefuga/go-collections/tests/benchmark"
+)
+
+func BenchmarkForPage(b *testing.B) {
+	slice := benchmark.BuildIntSlice()
+	size := len(slice) / 10
+
+	for n := 0; n < b.N; n++ {
+		collections.ForPage(slice, 5, size)
+	}
+}


### PR DESCRIPTION
# What?
add `ForPage`
# Why?
It's pretty useful
# How?
check for where the page items would be and then just return a slice between the bounds