### PR TITLE
Add internal relational util

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -502,13 +502,8 @@ func Interpose[V any](slice []V, sep V) []V {
 
 // ForPage returns a slice containing the items that would be present on a given page number
 func ForPage[V any](slice []V, page, size int) []V {
-	lower, upper := (page-1)*size, (page-1)*size+size
-	if upper > len(slice) {
-		upper = len(slice)
-	}
-	if lower < 0 || lower > upper {
-		return []V{}
-	}
+	lower := internal.Max((page-1)*size, 0)
+	upper := internal.Min(lower+size, len(slice))
 	return slice[lower:upper]
 }
 

--- a/generic.go
+++ b/generic.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/thefuga/go-collections/errors"
+	"github.com/thefuga/go-collections/internal"
 )
 
 // Get calls GetE, omitting the error.
@@ -464,7 +465,7 @@ func Reverse[V any](slice []V) []V {
 }
 
 // SumBy accumulates values returned by `f`
-func SumBy[V any, T Number](slice []V, f func(v V) T) T {
+func SumBy[V any, T internal.Number](slice []V, f func(v V) T) T {
 	var sum T
 	for _, v := range slice {
 		sum += f(v)
@@ -473,7 +474,7 @@ func SumBy[V any, T Number](slice []V, f func(v V) T) T {
 }
 
 // Range returns a slice containing integers in the specified range (i.e. [min, max])
-func Range[T Integer](min, max T) []T {
+func Range[T internal.Integer](min, max T) []T {
 	result := make([]T, max-min+1)
 	for i := range result {
 		result[i] = T(i) + min

--- a/generic_test.go
+++ b/generic_test.go
@@ -1790,11 +1790,11 @@ func TestForPage(t *testing.T) {
 			expected: []int{7, 8, 9},
 		},
 		{
-			name:     "page = 0",
+			name:     "page < 1 is equal to page = 1",
 			slice:    []int{1, 2, 3},
 			page:     0,
 			size:     3,
-			expected: []int{},
+			expected: []int{1, 2, 3},
 		},
 		{
 			name:     "page * size > len(slice)",

--- a/internal/constraints.go
+++ b/internal/constraints.go
@@ -1,4 +1,4 @@
-package collections
+package internal
 
 import "github.com/thefuga/go-collections/errors"
 

--- a/internal/relational.go
+++ b/internal/relational.go
@@ -1,0 +1,15 @@
+package internal
+
+func Min[T Relational](a, b T) T {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func Max[T Relational](a, b T) T {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/kv/collection.go
+++ b/kv/collection.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/thefuga/go-collections"
 	"github.com/thefuga/go-collections/errors"
+	"github.com/thefuga/go-collections/internal"
 	"github.com/thefuga/go-collections/slice"
 )
 
@@ -262,7 +263,7 @@ func (c Collection[K, V]) Flip() Collection[K, V] {
 
 // Flip makes a new collection, flipping the values with the keys.
 func (c Collection[K, V]) FlipE() (Collection[K, V], error) {
-	if _, err := collections.AssertE[V](*new(K)); err != nil {
+	if _, err := internal.AssertE[V](*new(K)); err != nil {
 		return c, err
 
 	}
@@ -270,8 +271,8 @@ func (c Collection[K, V]) FlipE() (Collection[K, V], error) {
 	flippedValues := make(map[K]V, c.Count())
 
 	c.Each(func(k K, v V) {
-		castKey, keyOk := collections.Assert[K](v)
-		castValue, valueOk := collections.Assert[V](k)
+		castKey, keyOk := internal.Assert[K](v)
+		castValue, valueOk := internal.Assert[V](k)
 
 		if keyOk && valueOk {
 			flippedValues[castKey] = castValue

--- a/kv/ordered/collection.go
+++ b/kv/ordered/collection.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/thefuga/go-collections"
 	"github.com/thefuga/go-collections/errors"
+	"github.com/thefuga/go-collections/internal"
 	"github.com/thefuga/go-collections/kv"
 	"github.com/thefuga/go-collections/slice"
 )
@@ -72,7 +73,7 @@ func Get[K comparable, T, V any](c Collection[K, V], k K) (T, error) {
 		return *new(T), getErr
 	}
 
-	return collections.AssertE[T](genericValue)
+	return internal.AssertE[T](genericValue)
 }
 
 // TODO
@@ -97,7 +98,7 @@ func (c *Collection[K, V]) Put(k K, v V) Collection[K, V] {
 // Push appends v to the end of the collection. The value will be associated with
 // a key corresponding to the count of the collection at the time of pushing.
 func (c *Collection[K, V]) Push(v V) Collection[K, V] {
-	if castK, ok := collections.Assert[K](c.Count()); ok {
+	if castK, ok := internal.Assert[K](c.Count()); ok {
 		c.Put(castK, v)
 	}
 
@@ -305,12 +306,12 @@ func (c Collection[K, V]) CombineE(values Collection[K, V]) (Collection[K, V], e
 	combined := makeCollection[K, V](c.Count())
 
 	for i := 0; i < c.Count(); i++ {
-		k, err := collections.AssertE[K](c.values[c.keys[i]])
+		k, err := internal.AssertE[K](c.values[c.keys[i]])
 		if err != nil {
 			return combined, err
 		}
 
-		v, err := collections.AssertE[V](values.values[values.keys[i]])
+		v, err := internal.AssertE[V](values.values[values.keys[i]])
 		if err != nil {
 			return combined, err
 		}
@@ -368,8 +369,8 @@ func (c Collection[K, V]) Flip() Collection[K, V] {
 	flippedValues := make(map[K]V, c.Count())
 
 	c.Each(func(k K, v V) {
-		castKey, keyOk := collections.Assert[K](v)
-		castValue, valueOk := collections.Assert[V](k)
+		castKey, keyOk := internal.Assert[K](v)
+		castValue, valueOk := internal.Assert[V](k)
 
 		if keyOk && valueOk {
 			flippedKeys = append(flippedKeys, castKey)

--- a/kv/ordered/numeric/collection.go
+++ b/kv/ordered/numeric/collection.go
@@ -2,17 +2,18 @@ package numeric
 
 import (
 	"github.com/thefuga/go-collections"
+	"github.com/thefuga/go-collections/internal"
 	"github.com/thefuga/go-collections/kv/ordered"
 )
 
 // Collection is an ordered collection which ensures all values are numbers. This
 // allows for methods that are only applicable to numbers, such as sums and so on.
-type Collection[K comparable, V collections.Number] struct {
+type Collection[K comparable, V internal.Number] struct {
 	ordered.Collection[K, V]
 }
 
 // Collect returns an ordered numeric collection containing the given values
-func Collect[V collections.Number](n ...V) Collection[int, V] {
+func Collect[V internal.Number](n ...V) Collection[int, V] {
 	return Collection[int, V]{ordered.Collect(n...)}
 }
 

--- a/matcher.go
+++ b/matcher.go
@@ -1,6 +1,10 @@
 package collections
 
-import "reflect"
+import (
+	"reflect"
+
+	"github.com/thefuga/go-collections/internal"
+)
 
 // Matcher is used by matchers on functions that  must compare keys and values from
 // a collection.
@@ -32,7 +36,7 @@ func ValueDiffers(value any) Matcher {
 
 // ValueGT compares the given numeric value to check if it is greater than the value
 // given by the matcher's caller.
-func ValueGT[T Number](value T) Matcher {
+func ValueGT[T internal.Number](value T) Matcher {
 	return func(_ any, collectionValue any) bool {
 		if cast, ok := collectionValue.(T); ok {
 			return value < cast
@@ -43,7 +47,7 @@ func ValueGT[T Number](value T) Matcher {
 
 // ValueLT compares the given numeric value to check if it is lesser than the value
 // given by the matcher's caller.
-func ValueLT[T Number](value T) Matcher {
+func ValueLT[T internal.Number](value T) Matcher {
 	return func(_ any, collectionValue any) bool {
 		if cast, ok := collectionValue.(T); ok {
 			return value > cast
@@ -143,7 +147,7 @@ func OrValue[V any](v V, matchers ...func(V) Matcher) Matcher {
 
 // Asc can be used as a Sort param to order collections in ascending order. It only
 // works on slices holding Relational values.
-func Asc[T Relational]() func(T, T) bool {
+func Asc[T internal.Relational]() func(T, T) bool {
 	return func(current, next T) bool {
 		return current < next
 	}
@@ -151,7 +155,7 @@ func Asc[T Relational]() func(T, T) bool {
 
 // Desc can be used as a Sort param to order collections in descending order. It only
 // works on slices holding Relational values.
-func Desc[T Relational]() func(T, T) bool {
+func Desc[T internal.Relational]() func(T, T) bool {
 	return func(current, next T) bool {
 		return current > next
 	}

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -1,6 +1,10 @@
 package collections
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/thefuga/go-collections/internal"
+)
 
 func TestKeyEquals(t *testing.T) {
 	if !KeyEquals("foo")("foo", nil) {
@@ -63,7 +67,7 @@ func TestAssert(t *testing.T) {
 	underlyingValue := "generic value"
 	var genericType any = underlyingValue
 
-	concreteType, _ = Assert[string](genericType)
+	concreteType, _ = internal.Assert[string](genericType)
 
 	if concreteType != underlyingValue {
 		t.Error("Expected concreteType to have the value of underlyingValue")
@@ -74,7 +78,7 @@ func TestAssertE(t *testing.T) {
 	underlyingValue := "generic value"
 	var genericType any = underlyingValue
 
-	concreteType, assertionErr := AssertE[string](genericType)
+	concreteType, assertionErr := internal.AssertE[string](genericType)
 
 	if assertionErr != nil {
 		t.Error("Unexpected error casting value.")
@@ -84,7 +88,7 @@ func TestAssertE(t *testing.T) {
 		t.Error("Expected concreteType to have the value of underlyingValue")
 	}
 
-	zeroValue, assertionErr := AssertE[int](genericType)
+	zeroValue, assertionErr := internal.AssertE[int](genericType)
 
 	if zeroValue != 0 {
 		t.Error("Cast value should be zeroed when an invalid type is given")

--- a/numeric.go
+++ b/numeric.go
@@ -2,10 +2,11 @@ package collections
 
 import (
 	"github.com/thefuga/go-collections/errors"
+	"github.com/thefuga/go-collections/internal"
 )
 
 // Sum sums all the values stored on the numeric slice and returns the result.
-func Sum[T Number](slice []T) T {
+func Sum[T internal.Number](slice []T) T {
 	var sum T
 
 	for _, v := range slice {
@@ -17,7 +18,7 @@ func Sum[T Number](slice []T) T {
 
 // AverageE calculates the average value of the slice. Should the slice be empty,
 // an instance of errors.EmptyCollectionError is returned.
-func AverageE[T Number](slice []T) (T, error) {
+func AverageE[T internal.Number](slice []T) (T, error) {
 	if len(slice) == 0 {
 		return *new(T), errors.NewEmptyCollectionError()
 	}
@@ -26,14 +27,14 @@ func AverageE[T Number](slice []T) (T, error) {
 }
 
 // Average uses AverageE, omitting the error.
-func Average[T Number](slice []T) T {
+func Average[T internal.Number](slice []T) T {
 	avg, _ := AverageE(slice)
 	return avg
 }
 
 // MinE returns the minimal value stored on the numeric slice. Should the slice be
 // empty, an error is returned.
-func MinE[T Number](slice []T) (T, error) {
+func MinE[T internal.Number](slice []T) (T, error) {
 	min, err := FirstE(slice)
 
 	if err != nil {
@@ -50,14 +51,14 @@ func MinE[T Number](slice []T) (T, error) {
 }
 
 // Min uses MinE, omitting the error.
-func Min[T Number](slice []T) T {
+func Min[T internal.Number](slice []T) T {
 	min, _ := MinE(slice)
 	return min
 }
 
 // MaxE returns the maximum value stored on the numeric slice. Should the slice be
 // empty, an error is returned.
-func MaxE[T Number](slice []T) (T, error) {
+func MaxE[T internal.Number](slice []T) (T, error) {
 	max, err := FirstE(slice)
 
 	if err != nil {
@@ -74,13 +75,13 @@ func MaxE[T Number](slice []T) (T, error) {
 }
 
 // Max uses MaxE, omitting the error.
-func Max[T Number](slice []T) T {
+func Max[T internal.Number](slice []T) T {
 	max, _ := MaxE(slice)
 	return max
 }
 
 // Median calculates and returns the median value of the slice.
-func Median[T Number](slice []T) float64 {
+func Median[T internal.Number](slice []T) float64 {
 	Sort(slice, Asc[T]())
 
 	halfway := int(len(slice) / 2)


### PR DESCRIPTION
# What?
add relational util functions
# Why?
to be able being able to get min, max, etc for ordered types without having to use `math` (and avoid all the type conversions that come with it)
# How?
I had to move `constraints` to `internal` to avoid cyclic dependencies. Other than that, I just added `Min` and `Max` to `internal` e refactored `ForPage` to use them
