### PR TITLE
feat(generic): add `Pad`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,7 @@ Not all methods will make sense on Go and won't be implemented.
 - [x] mode
 - [ ] nth
 - [x] only
-- [ ] pad
+- [x] pad
 - [x] partition
 - [ ] pipe
 - [ ] pipeInto

--- a/generic.go
+++ b/generic.go
@@ -534,9 +534,8 @@ func KeyBy[V any, K comparable](slice []V, f func(v V) K) map[K]V {
 	return result
 }
 
-// PadRigth will fill the slice with the given value and the specified size.
-// No padding will take place if the absolute value of the given size is less
-// than or equal to the length of the array
+// PadRigth will fill the slice with `pad` to the specified `size`.
+// No padding will take place if the `size` is less than or equal to the length of `slice`
 func PadRight[V any](slice []V, size int, pad V) []V {
 	if size <= len(slice) {
 		return slice
@@ -551,9 +550,8 @@ func PadRight[V any](slice []V, size int, pad V) []V {
 	return result
 }
 
-// PadLeft will fill the slice with the given value from the left to the specified size.
-// No padding will take place if the absolute value of the given size is less
-// than or equal to the length of the array
+// PadLeft will fill the slice with `pad` from the left to the specified `size`.
+// No padding will take place if the `size` is less than or equal to the length of `slice`
 func PadLeft[V any](slice []V, size int, pad V) []V {
 	if size <= len(slice) {
 		return slice
@@ -570,10 +568,9 @@ func PadLeft[V any](slice []V, size int, pad V) []V {
 	return result
 }
 
-// Pad will fill the slice with the given value and the specified size.
-// To pad to the left, you should specify a negative size.
-// No padding will take place if the absolute value of the given size is less
-// than or equal to the length of the array
+// Pad will fill the slice with `pad` to the specified `size`.
+// To pad to the left, specify a negative `size`.
+// No padding will take place if the absolute value of `size` is less than or equal to the length of `slice`
 func Pad[V any](slice []V, size int, pad V) []V {
 	if size >= 0 {
 		return PadRight(slice, size, pad)

--- a/generic.go
+++ b/generic.go
@@ -533,3 +533,43 @@ func KeyBy[V any, K comparable](slice []V, f func(v V) K) map[K]V {
 	}
 	return result
 }
+
+func PadRight[V any](slice []V, size int, filler V) []V {
+	if size <= len(slice) {
+		return slice
+	}
+
+	result := make([]V, size)
+	for i, v := range slice {
+		result[i] = v
+	}
+	for i := len(slice); i < size; i++ {
+		result[i] = filler
+	}
+	return result
+}
+
+func PadLeft[V any](slice []V, size int, filler V) []V {
+	if size <= len(slice) {
+		return slice
+	}
+
+	offset := size - len(slice)
+
+	result := make([]V, size)
+	for i, v := range slice {
+		result[i+offset] = v
+	}
+	for i := 0; i < offset; i++ {
+		result[i] = filler
+	}
+	return result
+}
+
+func Pad[V any](slice []V, size int, filler V) []V {
+	if size >= 0 {
+		return PadRight(slice, size, filler)
+	}
+
+	return PadLeft(slice, -size, filler)
+}

--- a/generic.go
+++ b/generic.go
@@ -534,7 +534,10 @@ func KeyBy[V any, K comparable](slice []V, f func(v V) K) map[K]V {
 	return result
 }
 
-func PadRight[V any](slice []V, size int, filler V) []V {
+// PadRigth will fill the slice with the given value and the specified size.
+// No padding will take place if the absolute value of the given size is less
+// than or equal to the length of the array
+func PadRight[V any](slice []V, size int, pad V) []V {
 	if size <= len(slice) {
 		return slice
 	}
@@ -544,12 +547,15 @@ func PadRight[V any](slice []V, size int, filler V) []V {
 		result[i] = v
 	}
 	for i := len(slice); i < size; i++ {
-		result[i] = filler
+		result[i] = pad
 	}
 	return result
 }
 
-func PadLeft[V any](slice []V, size int, filler V) []V {
+// PadLeft will fill the slice with the given value from the left to the specified size.
+// No padding will take place if the absolute value of the given size is less
+// than or equal to the length of the array
+func PadLeft[V any](slice []V, size int, pad V) []V {
 	if size <= len(slice) {
 		return slice
 	}
@@ -561,15 +567,19 @@ func PadLeft[V any](slice []V, size int, filler V) []V {
 		result[i+offset] = v
 	}
 	for i := 0; i < offset; i++ {
-		result[i] = filler
+		result[i] = pad
 	}
 	return result
 }
 
-func Pad[V any](slice []V, size int, filler V) []V {
+// Pad will fill the slice with the given value and the specified size.
+// To pad to the left, you should specify a negative size.
+// No padding will take place if the absolute value of the given size is less
+// than or equal to the length of the array
+func Pad[V any](slice []V, size int, pad V) []V {
 	if size >= 0 {
-		return PadRight(slice, size, filler)
+		return PadRight(slice, size, pad)
 	}
 
-	return PadLeft(slice, -size, filler)
+	return PadLeft(slice, -size, pad)
 }

--- a/generic.go
+++ b/generic.go
@@ -543,9 +543,8 @@ func PadRight[V any](slice []V, size int, pad V) []V {
 	}
 
 	result := make([]V, size)
-	for i, v := range slice {
-		result[i] = v
-	}
+	copy(result, slice)
+
 	for i := len(slice); i < size; i++ {
 		result[i] = pad
 	}
@@ -563,9 +562,8 @@ func PadLeft[V any](slice []V, size int, pad V) []V {
 	offset := size - len(slice)
 
 	result := make([]V, size)
-	for i, v := range slice {
-		result[i+offset] = v
-	}
+	copy(result[offset:], slice)
+
 	for i := 0; i < offset; i++ {
 		result[i] = pad
 	}

--- a/generic_test.go
+++ b/generic_test.go
@@ -1983,3 +1983,81 @@ func TestLastByE(t *testing.T) {
 		})
 	}
 }
+
+func TestPad(t *testing.T) {
+	testCases := []struct {
+		name     string
+		slice    []int
+		size     int
+		filler   int
+		expected []int
+	}{
+		{
+			name:     "fill to 5 with 1s",
+			slice:    []int{1, 2, 3},
+			size:     5,
+			filler:   1,
+			expected: []int{1, 2, 3, 1, 1},
+		},
+		{
+			name:     "fill empty slice to 5 with 5s",
+			slice:    []int{},
+			size:     5,
+			filler:   5,
+			expected: []int{5, 5, 5, 5, 5},
+		},
+		{
+			name:     "when size = len(slice), it returns the slice",
+			slice:    []int{1, 2, 3},
+			size:     3,
+			filler:   4,
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "when size < len(slice), it returns the slice",
+			slice:    []int{1, 2, 3},
+			size:     1,
+			filler:   4,
+			expected: []int{1, 2, 3},
+		},
+
+		// negative cases (pad left)
+		{
+			name:     "fill to 5 with 1s",
+			slice:    []int{1, 2, 3},
+			size:     -5,
+			filler:   3,
+			expected: []int{3, 3, 1, 2, 3},
+		},
+		{
+			name:     "fill empty slice to 5 with 5s",
+			slice:    []int{},
+			size:     -5,
+			filler:   5,
+			expected: []int{5, 5, 5, 5, 5},
+		},
+		{
+			name:     "when size = len(slice), it returns the slice",
+			slice:    []int{1, 2, 3},
+			size:     -3,
+			filler:   4,
+			expected: []int{1, 2, 3},
+		},
+		{
+			name:     "when size < len(slice), it returns the slice",
+			slice:    []int{1, 2, 3},
+			size:     -1,
+			filler:   4,
+			expected: []int{1, 2, 3},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			if got := Pad(tc.slice, tc.size, tc.filler); !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("Expected '%v'. Got '%v'", tc.expected, got)
+			}
+		})
+	}
+}

--- a/generic_test.go
+++ b/generic_test.go
@@ -1989,35 +1989,35 @@ func TestPad(t *testing.T) {
 		name     string
 		slice    []int
 		size     int
-		filler   int
+		pad      int
 		expected []int
 	}{
 		{
 			name:     "fill to 5 with 1s",
 			slice:    []int{1, 2, 3},
 			size:     5,
-			filler:   1,
+			pad:      1,
 			expected: []int{1, 2, 3, 1, 1},
 		},
 		{
 			name:     "fill empty slice to 5 with 5s",
 			slice:    []int{},
 			size:     5,
-			filler:   5,
+			pad:      5,
 			expected: []int{5, 5, 5, 5, 5},
 		},
 		{
 			name:     "when size = len(slice), it returns the slice",
 			slice:    []int{1, 2, 3},
 			size:     3,
-			filler:   4,
+			pad:      4,
 			expected: []int{1, 2, 3},
 		},
 		{
 			name:     "when size < len(slice), it returns the slice",
 			slice:    []int{1, 2, 3},
 			size:     1,
-			filler:   4,
+			pad:      4,
 			expected: []int{1, 2, 3},
 		},
 
@@ -2026,28 +2026,28 @@ func TestPad(t *testing.T) {
 			name:     "fill to 5 with 1s",
 			slice:    []int{1, 2, 3},
 			size:     -5,
-			filler:   3,
+			pad:      3,
 			expected: []int{3, 3, 1, 2, 3},
 		},
 		{
 			name:     "fill empty slice to 5 with 5s",
 			slice:    []int{},
 			size:     -5,
-			filler:   5,
+			pad:      5,
 			expected: []int{5, 5, 5, 5, 5},
 		},
 		{
 			name:     "when size = len(slice), it returns the slice",
 			slice:    []int{1, 2, 3},
 			size:     -3,
-			filler:   4,
+			pad:      4,
 			expected: []int{1, 2, 3},
 		},
 		{
 			name:     "when size < len(slice), it returns the slice",
 			slice:    []int{1, 2, 3},
 			size:     -1,
-			filler:   4,
+			pad:      4,
 			expected: []int{1, 2, 3},
 		},
 	}
@@ -2055,7 +2055,7 @@ func TestPad(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			if got := Pad(tc.slice, tc.size, tc.filler); !reflect.DeepEqual(got, tc.expected) {
+			if got := Pad(tc.slice, tc.size, tc.pad); !reflect.DeepEqual(got, tc.expected) {
 				t.Errorf("Expected '%v'. Got '%v'", tc.expected, got)
 			}
 		})

--- a/tests/benchmark/generic/pad_test.go
+++ b/tests/benchmark/generic/pad_test.go
@@ -1,0 +1,17 @@
+package generic
+
+import (
+	"testing"
+
+	"github.com/thefuga/go-collections"
+	"github.com/thefuga/go-collections/tests/benchmark"
+)
+
+func BenchmarkPad(b *testing.B) {
+	slice := benchmark.BuildIntSlice()
+	half := len(slice) / 2
+
+	for n := 0; n < b.N; n++ {
+		collections.Pad(slice[:half], len(slice), 0)
+	}
+}


### PR DESCRIPTION
# What?
add `Pad`

https://laravel.com/docs/9.x/collections#method-pad
# Why?
It's on the todo list
# How?
I first implemented `PadRight` and `PadLeft` (since Laravel does both in the same function depending on the `size` argument) and was planning to leave it that way. But since I had both methods and to mimic Laravel all that was missing was just a sign check.....