### PR TITLE
fix(generic): fix Copy

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -196,7 +196,7 @@ func Sort[T any](slice []T, f func(current, next T) bool) {
 // Copy returns a copy of the input slice.
 func Copy[V any](slice []V) []V {
 	copied := make([]V, len(slice))
-	copy(slice, copied)
+	copy(copied, slice)
 	return copied
 }
 

--- a/generic_test.go
+++ b/generic_test.go
@@ -572,6 +572,10 @@ func TestCopy(t *testing.T) {
 	if to := Copy(from); !reflect.DeepEqual(from, to) {
 		t.Errorf("expected copied slice to be %v. got %v", from, to)
 	}
+
+	if !reflect.DeepEqual(from, []string{"foo", "bar", "baz"}) {
+		t.Errorf("copy must not change source")
+	}
 }
 
 func TestCut(t *testing.T) {


### PR DESCRIPTION
# What?
fix `Copy`
# Why?
because it's wrong
# How?
by changing the order of the parameters given to `copy`
