### PR TITLE
fix(generic): fix `Map` return type

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -167,8 +167,8 @@ func SearchE[T any](v T, slice []T) (int, error) {
 // Map applies f to each element of the slice and builds a new slice with f's returned
 // value. The built slice is returned.
 // The mapped slice has the same order as the input slice.
-func Map[T any](f func(i int, v T) T, slice []T) []T {
-	mappedValues := make([]T, 0, len(slice))
+func Map[T any, R any](f func(i int, v T) R, slice []T) []R {
+	mappedValues := make([]R, 0, len(slice))
 
 	Each(func(i int, v T) {
 		mappedValues = Push(f(i, v), mappedValues)

--- a/generic_test.go
+++ b/generic_test.go
@@ -3,6 +3,7 @@ package collections
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/thefuga/go-collections/errors"
@@ -372,6 +373,18 @@ func TestMap(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestMappingToADifferentType(t *testing.T) {
+	slice := []int{1, 2, 3}
+	mapper := func(_ int, n int) string {
+		return strconv.Itoa(n)
+	}
+	expected := []string{"1", "2", "3"}
+
+	if got := Map(mapper, slice); !reflect.DeepEqual(got, expected) {
+		t.Errorf("Expected '%v'. Got '%v'", expected, got)
 	}
 }
 


### PR DESCRIPTION
# What?
change the return type of `Map` to depend on the return type of `f`
# Why?
this is the correct signature [according to haskell](http://learnyouahaskell.com/higher-order-functions#maps-and-filters)
# How?
adding another "type parameter"(?) to `Map`
