### PR TITLE
feat(generic): add `Splice` and `SpliceN`

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -93,7 +93,7 @@ Not all methods will make sense on Go and won't be implemented.
 - [ ] sortKeys
 - [ ] sortKeysDesc
 - [ ] sortKeysUsing
-- [ ] splice
+- [x] splice (Splice, SpliceN)
 - [ ] split
 - [ ] splitIn
 - [x] sum (Sum, SumBy)

--- a/generic.go
+++ b/generic.go
@@ -687,6 +687,8 @@ func Sliding[V any](slice []V, window int) [][]V {
 	return SlidingStep(slice, window, 1)
 }
 
+// Splice returns a slice of items starting at the specified index,
+// and the updated slice with the items removed.
 func Splice[V any](slice []V, idx int) ([]V, []V) {
 	if idx >= len(slice) {
 		return nil, nil
@@ -694,6 +696,8 @@ func Splice[V any](slice []V, idx int) ([]V, []V) {
 	return slice[idx:], slice[:idx]
 }
 
+// Splice returns a slice of `slice` starting at the `index` with length `size`,
+// and the updated slice with the items removed.
 func SpliceN[V any](slice []V, idx, size int) ([]V, []V) {
 	if idx < 0 || size < 1 {
 		return nil, nil

--- a/generic.go
+++ b/generic.go
@@ -696,7 +696,7 @@ func Splice[V any](slice []V, idx int) ([]V, []V) {
 	return slice[idx:], slice[:idx]
 }
 
-// Splice returns a slice of `slice` starting at the `index` with length `size`,
+// SpliceN returns a slice of `slice` starting at the `index` with length `size`,
 // and the updated slice with the items removed.
 func SpliceN[V any](slice []V, idx, size int) ([]V, []V) {
 	if idx < 0 || size < 1 {

--- a/generic.go
+++ b/generic.go
@@ -201,7 +201,7 @@ func SortBy[T any, S internal.Relational](slice []T, f func(t T) S) []T {
 	return slice
 }
 
-// SortByDesc sorts desc `slice` based on f. 
+// SortByDesc sorts desc `slice` based on f.
 func SortByDesc[T any, S internal.Relational](slice []T, f func(t T) S) []T {
 	sort.Slice(slice, func(i, j int) bool {
 		return f(slice[i]) > f(slice[j])
@@ -685,4 +685,27 @@ func SlidingStep[V any](slice []V, window, step int) [][]V {
 // Sliding returns a "sliding window" view of the items in `slice`
 func Sliding[V any](slice []V, window int) [][]V {
 	return SlidingStep(slice, window, 1)
+}
+
+func Splice[V any](slice []V, idx int) ([]V, []V) {
+	if idx >= len(slice) {
+		return nil, nil
+	}
+	return slice[idx:], slice[:idx]
+}
+
+func SpliceN[V any](slice []V, idx, size int) ([]V, []V) {
+	if idx < 0 || size < 1 {
+		return nil, nil
+	}
+
+	if idx >= len(slice) {
+		return nil, slice
+	}
+
+	if idx+size > len(slice) {
+		size = len(slice) - idx
+	}
+
+	return Copy(slice[idx : idx+size]), append(slice[:idx], slice[idx+size:]...)
 }

--- a/generic_test.go
+++ b/generic_test.go
@@ -2632,3 +2632,162 @@ func TestSlidingStep(t *testing.T) {
 		})
 	}
 }
+
+func TestSplice(t *testing.T) {
+	testCases := []struct {
+		name          string
+		slice         []int
+		idx           int
+		expectedChunk []int
+		expectedSlice []int
+	}{
+		{
+			name:          "1 through 5 splicing at 2",
+			slice:         []int{1, 2, 3, 4, 5},
+			idx:           2,
+			expectedChunk: []int{3, 4, 5},
+			expectedSlice: []int{1, 2},
+		},
+		{
+			name:          "splicing at the last element",
+			slice:         []int{1, 2, 3},
+			idx:           2,
+			expectedChunk: []int{3},
+			expectedSlice: []int{1, 2},
+		},
+		{
+			name:          "splicing after the last element",
+			slice:         []int{1, 2, 3},
+			idx:           3,
+			expectedChunk: nil,
+			expectedSlice: nil,
+		},
+		{
+			name:          "empty slice",
+			slice:         []int{},
+			idx:           2,
+			expectedChunk: nil,
+			expectedSlice: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			chunk, slice := Splice(tc.slice, tc.idx)
+
+			if !reflect.DeepEqual(chunk, tc.expectedChunk) {
+				t.Errorf("Expected chunk '%v'. Got '%v'", tc.expectedChunk, chunk)
+			}
+
+			if !reflect.DeepEqual(slice, tc.expectedSlice) {
+				t.Errorf("Expected slice to change to '%v'. Got '%v'", tc.expectedSlice, slice)
+			}
+		})
+	}
+}
+
+func TestSpliceN(t *testing.T) {
+	testCases := []struct {
+		name          string
+		slice         []int
+		idx           int
+		size          int
+		expectedChunk []int
+		expectedSlice []int
+	}{
+		{
+			name:          "1 through 5 splicing at 2 with size 1",
+			slice:         []int{1, 2, 3, 4, 5},
+			idx:           2,
+			size:          1,
+			expectedChunk: []int{3},
+			expectedSlice: []int{1, 2, 4, 5},
+		},
+		{
+			name:          "1 through 5 splicing at 2 with size 2",
+			slice:         []int{1, 2, 3, 4, 5},
+			idx:           2,
+			size:          2,
+			expectedChunk: []int{3, 4},
+			expectedSlice: []int{1, 2, 5},
+		},
+		{
+			name:          "1 through 5 splicing at 2 with size 3",
+			slice:         []int{1, 2, 3, 4, 5},
+			idx:           2,
+			size:          3,
+			expectedChunk: []int{3, 4, 5},
+			expectedSlice: []int{1, 2},
+		},
+		{
+			name:          "1 through 5 splicing at 0 with size 5",
+			slice:         []int{1, 2, 3, 4, 5},
+			idx:           0,
+			size:          5,
+			expectedChunk: []int{1, 2, 3, 4, 5},
+			expectedSlice: []int{},
+		},
+		{
+			name:          "1 through 5 splicing at 0 with size 6",
+			slice:         []int{1, 2, 3, 4, 5},
+			idx:           0,
+			size:          6,
+			expectedChunk: []int{1, 2, 3, 4, 5},
+			expectedSlice: []int{},
+		},
+		{
+			name:          "index greater than the length of the slice",
+			slice:         []int{1, 2, 3, 4, 5},
+			idx:           5,
+			size:          1,
+			expectedChunk: nil,
+			expectedSlice: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:          "index plus size greater than the length of the slice",
+			slice:         []int{1, 2, 3, 4, 5},
+			idx:           2,
+			size:          4,
+			expectedChunk: []int{3, 4, 5},
+			expectedSlice: []int{1, 2},
+		},
+		{
+			name:          "negative index",
+			slice:         []int{1, 2, 3},
+			idx:           -1,
+			size:          4,
+			expectedChunk: nil,
+			expectedSlice: nil,
+		},
+		{
+			name:          "zero size",
+			slice:         []int{1, 2, 3},
+			idx:           0,
+			size:          0,
+			expectedChunk: nil,
+			expectedSlice: nil,
+		},
+		{
+			name:          "negative size",
+			slice:         []int{1, 2, 3},
+			idx:           0,
+			size:          -1,
+			expectedChunk: nil,
+			expectedSlice: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			chunk, slice := SpliceN(tc.slice, tc.idx, tc.size)
+
+			if !reflect.DeepEqual(chunk, tc.expectedChunk) {
+				t.Errorf("Expected chunk '%v'. Got '%v'", tc.expectedChunk, chunk)
+			}
+
+			if !reflect.DeepEqual(slice, tc.expectedSlice) {
+				t.Errorf("Expected slice to change to '%v'. Got '%v'", tc.expectedSlice, slice)
+			}
+		})
+	}
+}

--- a/tests/benchmark/generic/splice_n_test.go
+++ b/tests/benchmark/generic/splice_n_test.go
@@ -1,0 +1,18 @@
+package generic
+
+import (
+	"testing"
+
+	. "github.com/thefuga/go-collections"
+	"github.com/thefuga/go-collections/tests/benchmark"
+)
+
+func BenchmarkSpliceN(b *testing.B) {
+	slice := benchmark.BuildIntSlice()
+	spliceAt := len(slice) / 2
+	splitSize := len(slice) / 2
+
+	for n := 0; n < b.N; n++ {
+		SpliceN(slice, spliceAt, splitSize)
+	}
+}

--- a/tests/benchmark/generic/splice_test.go
+++ b/tests/benchmark/generic/splice_test.go
@@ -1,0 +1,17 @@
+package generic
+
+import (
+	"testing"
+
+	. "github.com/thefuga/go-collections"
+	"github.com/thefuga/go-collections/tests/benchmark"
+)
+
+func BenchmarkSplice(b *testing.B) {
+	slice := benchmark.BuildIntSlice()
+	spliceAt := len(slice) / 2
+
+	for n := 0; n < b.N; n++ {
+		Splice(slice, spliceAt)
+	}
+}


### PR DESCRIPTION
# What?
add `Splice` and `SpliceN`
https://laravel.com/docs/9.x/collections#method-splice

# Why?
It's on the todo list

# How?
I had to create two functions since Laravel accepts an optional argument for specifying the size of the chunk.

For `Splice` I just returned two slices. Honestly, it looks like `SplitAt`

I decided to call the version that accepts size `SpliceN`. This one is a little tricky because of all the bound checks, but essentially it just returns a copy of the slice from the specified index with the specified size and also returns a slice with those elements removed.


Oh, Laravel's splice also accepts a THIRD optional argument (of course it does...) for specified replacement items, and I decided to leave it off of this PR 'cause this one it's long enough as it is... So if y'all think it makes sense to add that one too, leave a comment and I'll put up another PR adding it.
