### PR TITLE
refactor(matcher): split `ValueEquals` into generic and reflect versions

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -305,7 +305,7 @@ func Mode[T comparable](slice []T) []T {
 }
 
 // Contains checks if the slice holds at least one value matching the given matcher.
-func Contains[V any](slice []V, matcher AnyMatcher) bool {
+func Contains[V any](slice []V, matcher Matcher[int, V]) bool {
 	for i, v := range slice {
 		if matcher(i, v) {
 			return true

--- a/generic_test.go
+++ b/generic_test.go
@@ -971,7 +971,7 @@ func TestFirstWhereField(t *testing.T) {
 			"slice contains a matching object",
 			users,
 			"Name",
-			ValueEquals("Alice"),
+			ValueDeepEquals[any, any]("Alice"),
 			user{Name: "Alice", Email: "alice@collections.go", Age: 40},
 		},
 		{
@@ -1012,7 +1012,7 @@ func TestFirstWhereFieldE(t *testing.T) {
 			"slice contains a matching object",
 			users,
 			"Name",
-			ValueEquals("Alice"),
+			ValueDeepEquals[any, any]("Alice"),
 			user{Name: "Alice", Email: "alice@collections.go", Age: 40},
 			nil,
 		},
@@ -1189,19 +1189,19 @@ func TestContains(t *testing.T) {
 	testCases := []struct {
 		description string
 		slice       []int
-		matcher     AnyMatcher
+		matcher     Matcher[int, int]
 		contains    bool
 	}{
 		{
 			"collection contains at least one matching value",
 			[]int{1, 2, 3, 4},
-			ValueEquals(3),
+			ValueEquals[int](3),
 			true,
 		},
 		{
 			"collection does not contain matching values",
 			[]int{1, 2, 3, 4},
-			ValueEquals(5),
+			ValueEquals[int](5),
 			false,
 		},
 	}
@@ -2198,7 +2198,7 @@ func TestRandomResultIsIncludedInSlice(t *testing.T) {
 
 	for i := 0; i < 10; i++ {
 		rand := Random(slice)
-		if !Contains(slice, ValueEquals(rand)) {
+		if !Contains(slice, ValueEquals[int](rand)) {
 			t.Errorf("expected slice '%v' to contain '%v'", slice, rand)
 		}
 	}
@@ -2319,7 +2319,7 @@ func TestSkipUntil(t *testing.T) {
 		{
 			name:     "after 3",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueEquals(3),
+			matcher:  ValueDeepEquals[any, any](3),
 			expected: []int{3, 4, 5},
 		},
 		{

--- a/kv/collection.go
+++ b/kv/collection.go
@@ -240,7 +240,7 @@ func (c Collection[K, V]) Concat(concatTo Collection[K, V]) Collection[K, V] {
 }
 
 // Contains checks if any values on the Collection match f.
-func (c Collection[K, V]) Contains(f collections.AnyMatcher) bool {
+func (c Collection[K, V]) Contains(f collections.Matcher[int, V]) bool {
 	return c.Values().Contains(f)
 }
 

--- a/kv/collection_test.go
+++ b/kv/collection_test.go
@@ -534,7 +534,7 @@ func TestContains(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			if contains := tc.collection.Contains(collections.ValueEquals(tc.value)); contains != tc.contains {
+			if contains := tc.collection.Contains(collections.ValueEquals[int](tc.value)); contains != tc.contains {
 				t.Errorf("Contains result should be %v. got %v", tc.contains, contains)
 			}
 		})
@@ -564,7 +564,7 @@ func TestEvery(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			if contains := tc.collection.Every(collections.ValueEquals(tc.value)); contains != tc.contains {
+			if contains := tc.collection.Every(collections.ValueDeepEquals[any, any](tc.value)); contains != tc.contains {
 				t.Errorf("Contains result should be %v. got %v", tc.contains, contains)
 			}
 		})

--- a/kv/ordered/collection_test.go
+++ b/kv/ordered/collection_test.go
@@ -551,7 +551,7 @@ func TestContainsKey(t *testing.T) {
 func TestContainsValue(t *testing.T) {
 	collection := CollectMap(map[string]string{"foo": "a", "bar": "b"})
 
-	if !collection.Contains(collections.ValueEquals("a")) {
+	if !collection.Contains(collections.ValueDeepEquals[any, any]("a")) {
 		t.Error("collection should contain 'a' value")
 	}
 }
@@ -559,13 +559,13 @@ func TestContainsValue(t *testing.T) {
 func TestEvery(t *testing.T) {
 	collection := Collect(2, 2, 2, 2)
 
-	if !collection.Every(collections.ValueEquals(2)) {
+	if !collection.Every(collections.ValueDeepEquals[any, any](2)) {
 		t.Error("all elements in the collection are equal")
 	}
 
 	collection.Put(4, 1)
 
-	if collection.Every(collections.ValueEquals(2)) {
+	if collection.Every(collections.ValueDeepEquals[any, any](2)) {
 		t.Error("the collection contains a different element")
 	}
 }
@@ -579,7 +579,7 @@ func TestFirstOrFail(t *testing.T) {
 		collection = Collect("foo", "bar")
 	)
 
-	foundKey, foundValue, foundErr = collection.FirstOrFail(collections.ValueEquals("bar"))
+	foundKey, foundValue, foundErr = collection.FirstOrFail(collections.ValueDeepEquals[any, any]("bar"))
 	if foundKey != 1 || foundValue != "bar" || foundErr != nil {
 		t.Errorf(
 			"Expected %d, %s, %v, got %d, %s, %v",
@@ -588,7 +588,7 @@ func TestFirstOrFail(t *testing.T) {
 		)
 	}
 
-	foundKey, foundValue, foundErr = collection.FirstOrFail(collections.ValueEquals("baz"))
+	foundKey, foundValue, foundErr = collection.FirstOrFail(collections.ValueDeepEquals[any, any]("baz"))
 	if foundKey != 0 || foundValue != "" || foundErr == nil {
 		t.Errorf(
 			"Expected %d, %s, %v, got %d, %s, %v",

--- a/kv/ordered/example_test.go
+++ b/kv/ordered/example_test.go
@@ -215,7 +215,7 @@ func ExampleCollection_Contains() {
 func ExampleCollection_Every() {
 	c := Collect(2, 2, 2, 2)
 
-	fmt.Printf("%v", c.Every(collections.ValueEquals(2)))
+	fmt.Printf("%v", c.Every(collections.ValueDeepEquals[any, any](2)))
 	// Output:
 	// true
 }

--- a/matcher.go
+++ b/matcher.go
@@ -19,11 +19,19 @@ func KeyEquals(key any) AnyMatcher {
 	}
 }
 
-// ValueEquals builds a matcher to compare the given value (with reflect.DeepEqual)
+// ValueDeepEquals builds a matcher to compare the given value (with reflect.DeepEqual)
 // to the value passed by the matcher caller.
-func ValueEquals(value any) AnyMatcher {
-	return func(_ any, collectionValue any) bool {
+func ValueDeepEquals[K any, V any](value V) Matcher[K, V] {
+	return func(_ K, collectionValue V) bool {
 		return reflect.DeepEqual(value, collectionValue)
+	}
+}
+
+// ValueEquals builds a matcher to compare the given value (with ==)
+// to the value passed by the matcher caller.
+func ValueEquals[K any, V comparable](value V) Matcher[K, V] {
+	return func(_ K, collectionValue V) bool {
+		return value == collectionValue
 	}
 }
 
@@ -59,7 +67,7 @@ func ValueLT[T internal.Number](value T) AnyMatcher {
 
 // FieldEquals uses FieldMatch composed with ValueEquals as the matcher.
 func FieldEquals[V any](field string, value any) AnyMatcher {
-	return FieldMatch[V](field, ValueEquals(value))
+	return FieldMatch[V](field, ValueDeepEquals[any, any](value))
 }
 
 // FieldMatch will attempt to retrieve the value corresponding to the given struct
@@ -87,8 +95,8 @@ func FieldMatch[V any](field string, matcher AnyMatcher) AnyMatcher {
 }
 
 // Not inverts the result of `matcher`
-func Not(matcher AnyMatcher) AnyMatcher {
-	return func(key any, value any) bool {
+func Not[K any, V any](matcher Matcher[K, V]) Matcher[K, V] {
+	return func(key K, value V) bool {
 		return !matcher(key, value)
 	}
 }

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -17,11 +17,28 @@ func TestKeyEquals(t *testing.T) {
 }
 
 func TestValueEquals(t *testing.T) {
-	if !ValueEquals("foo")(nil, "foo") {
+	if !ValueEquals[int]("foo")(1, "foo") {
 		t.Error("both values are equal")
 	}
 
-	if ValueEquals("foo")(nil, "bar") {
+	if ValueEquals[int]("foo")(1, "bar") {
+		t.Error("values are different")
+	}
+}
+
+func TestValueDeepEquals(t *testing.T) {
+	type user struct {
+		name string
+	}
+	bob1 := user{"bob"}
+	bob2 := user{"bob"}
+	alice := user{"alice"}
+
+	if !ValueDeepEquals[int](bob1)(1, bob2) {
+		t.Error("both values are equal")
+	}
+
+	if ValueDeepEquals[int](bob1)(1, alice) {
 		t.Error("values are different")
 	}
 }
@@ -116,7 +133,7 @@ func TestFieldMatch(t *testing.T) {
 }
 
 func TestNot(t *testing.T) {
-	matcher := ValueEquals(1)
+	matcher := ValueEquals[int](1)
 	notMatcher := Not(matcher)
 
 	if notMatcher(0, 1) == matcher(0, 1) {

--- a/slice/collection.go
+++ b/slice/collection.go
@@ -18,7 +18,7 @@ func Collect[V any](values ...V) Collection[V] {
 }
 
 // Contains passes the collection and the given params to the generic Contains function.
-func (c Collection[V]) Contains(matcher collections.AnyMatcher) bool {
+func (c Collection[V]) Contains(matcher collections.Matcher[int, V]) bool {
 	return collections.Contains(c, matcher)
 }
 

--- a/slice/collection_test.go
+++ b/slice/collection_test.go
@@ -536,19 +536,19 @@ func TestContains(t *testing.T) {
 	testCases := []struct {
 		description string
 		collection  Collection[int]
-		matcher     collections.AnyMatcher
+		matcher     collections.Matcher[int, int]
 		contains    bool
 	}{
 		{
 			"collection contains at least one matching value",
 			Collect(1, 2, 3, 4),
-			collections.ValueEquals(3),
+			collections.ValueEquals[int](3),
 			true,
 		},
 		{
 			"collection does not contain matching values",
 			Collect(1, 2, 3, 4),
-			collections.ValueEquals(5),
+			collections.ValueEquals[int](5),
 			false,
 		},
 	}

--- a/tests/benchmark/generic/contains_test.go
+++ b/tests/benchmark/generic/contains_test.go
@@ -1,0 +1,26 @@
+package generic
+
+import (
+	"testing"
+
+	. "github.com/thefuga/go-collections"
+	"github.com/thefuga/go-collections/tests/benchmark"
+)
+
+func BenchmarkContains(b *testing.B) {
+	slice := benchmark.BuildIntSlice()
+	half := len(slice) / 2
+
+	for n := 0; n < b.N; n++ {
+		Contains(slice, ValueEquals[int](half))
+	}
+}
+
+func BenchmarkContainsWithDeepMatcher(b *testing.B) {
+	slice := benchmark.BuildIntSlice()
+	half := len(slice) / 2
+
+	for n := 0; n < b.N; n++ {
+		Contains(slice, ValueDeepEquals[int](half))
+	}
+}


### PR DESCRIPTION
# What?
make `ValueEquals` "type safe" and add `ValueDeepEquals` with the previous value equals behavior
# Why?
it's BLAZINGLY FAST ™️

```text
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
BenchmarkContains-16                     1678250               736.7 ns/op            24 B/op          1 allocs/op
BenchmarkContainsWithDeepMatcher-16        64418             17942 ns/op            5992 B/op        747 allocs/op
```
# How?
adding type parameters and refactoring uses.
