### PR TITLE
refactor: add type params to generic functions matchers

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -316,14 +316,14 @@ func Contains[V any](slice []V, matcher Matcher[int, V]) bool {
 }
 
 // FirstWhere uses FirstWhereE, omitting the error.
-func FirstWhere[V any](slice []V, matcher AnyMatcher) V {
+func FirstWhere[V any](slice []V, matcher Matcher[int, V]) V {
 	v, _ := FirstWhereE(slice, matcher)
 	return v
 }
 
 // FirstWhereE returns the first value matched by the given matcher. Should no value
 // match, an instance of errors.ValueNotFoundError is returned.
-func FirstWhereE[V any](slice []V, matcher AnyMatcher) (V, error) {
+func FirstWhereE[V any](slice []V, matcher Matcher[int, V]) (V, error) {
 	for i, v := range slice {
 		if matcher(i, v) {
 			return v, nil
@@ -661,19 +661,18 @@ func Skip[V any](slice []V, skip int) []V {
 
 // SkipUntil skips over items from `slice` until `matcher` returns true and
 // then returns the remaining items in the slice
-func SkipUntil[V any](slice []V, matcher AnyMatcher) []V {
+func SkipUntil[V any](slice []V, matcher Matcher[int, V]) []V {
 	for i, v := range slice {
 		if matcher(i, v) {
 			return slice[i:]
 		}
 	}
-
 	return slice[len(slice):]
 }
 
 // SkipWhile skips over items from `slice` while `matcher` returns true and
 // then returns the remaining items in the slice
-func SkipWhile[V any](slice []V, matcher AnyMatcher) []V {
+func SkipWhile[V any](slice []V, matcher Matcher[int, V]) []V {
 	return SkipUntil(slice, Not(matcher))
 }
 
@@ -779,7 +778,7 @@ func Take[V any](slice []V, n int) []V {
 }
 
 // TakeWhile returns items in the `slice` until `matcher` returns false
-func TakeWhile[V any](slice []V, matcher AnyMatcher) []V {
+func TakeWhile[V any](slice []V, matcher Matcher[int, V]) []V {
 	for i, v := range slice {
 		if !matcher(i, v) {
 			return slice[:i]
@@ -790,7 +789,7 @@ func TakeWhile[V any](slice []V, matcher AnyMatcher) []V {
 }
 
 // TakeUntil returns items in the `slice` until `matcher` returns true
-func TakeUntil[V any](slice []V, matcher AnyMatcher) []V {
+func TakeUntil[V any](slice []V, matcher Matcher[int, V]) []V {
 	return TakeWhile(slice, Not(matcher))
 }
 

--- a/generic_test.go
+++ b/generic_test.go
@@ -978,7 +978,7 @@ func TestFirstWhereField(t *testing.T) {
 			"criteria doesn't match slice elements",
 			users,
 			"Age",
-			ValueGT(50),
+			ValueCastGT(50),
 			user{},
 		},
 	}
@@ -1020,7 +1020,7 @@ func TestFirstWhereFieldE(t *testing.T) {
 			"slice contains an object matching custom matcher",
 			users,
 			"Age",
-			ValueGT(30),
+			ValueCastGT(30),
 			user{Name: "Jon", Email: "jon@collections.go", Age: 33},
 			nil,
 		},
@@ -1028,7 +1028,7 @@ func TestFirstWhereFieldE(t *testing.T) {
 			"criteria doesn't match slice elements",
 			users,
 			"Age",
-			ValueGT(50),
+			ValueCastGT(50),
 			user{},
 			fmt.Errorf("value not found"),
 		},
@@ -1057,21 +1057,21 @@ func TestFirstWhereE(t *testing.T) {
 	testCases := []struct {
 		description string
 		sut         []int
-		matcher     AnyMatcher
+		matcher     Matcher[int, int]
 		v           int
 		err         error
 	}{
 		{
 			"slice contains a matching value",
 			slice,
-			ValueGT(3),
+			ValueGT[int](3),
 			4,
 			nil,
 		},
 		{
 			"slice does not contain matching values",
 			slice,
-			ValueGT(5),
+			ValueGT[int](5),
 			*new(int),
 			fmt.Errorf("value not found"),
 		},
@@ -1106,7 +1106,7 @@ func TestFirstWhereWithComposedMatchers(t *testing.T) {
 		description string
 		sut         []user
 		field       string
-		matcher     AnyMatcher
+		matcher     Matcher[int, user]
 		user        user
 		err         error
 	}{
@@ -1114,7 +1114,7 @@ func TestFirstWhereWithComposedMatchers(t *testing.T) {
 			"slice contains a matching object composed with 'AndValue'",
 			users,
 			"Name",
-			AndValue(user{Name: "Alice", Age: 40}, usernameMatch, ageMatch),
+			AndValue[int](user{Name: "Alice", Age: 40}, usernameMatch[int], ageMatch[int]),
 			user{Name: "Alice", Email: "alice@collections.go", Age: 40},
 			nil,
 		},
@@ -1122,7 +1122,7 @@ func TestFirstWhereWithComposedMatchers(t *testing.T) {
 			"slice contains a matching object composed with 'OrValue'",
 			users,
 			"Name",
-			OrValue(user{Name: "Alice", Age: 33}, usernameMatch, ageMatch),
+			OrValue[int](user{Name: "Alice", Age: 33}, usernameMatch[int], ageMatch[int]),
 			user{Name: "Jon", Email: "jon@collections.go", Age: 33},
 			nil,
 		},
@@ -1130,7 +1130,7 @@ func TestFirstWhereWithComposedMatchers(t *testing.T) {
 			"slice does not contain matching objects",
 			users,
 			"Name",
-			AndValue(user{Name: "Alice", Age: 33}, usernameMatch, ageMatch),
+			AndValue[int](user{Name: "Alice", Age: 33}, usernameMatch[int], ageMatch[int]),
 			user{},
 			fmt.Errorf("value not found"),
 		},
@@ -1159,19 +1159,19 @@ func TestFirstWhere(t *testing.T) {
 	testCases := []struct {
 		description string
 		sut         []int
-		matcher     AnyMatcher
+		matcher     Matcher[int, int]
 		v           int
 	}{
 		{
 			"slice contains a matching value",
 			slice,
-			ValueGT(3),
+			ValueGT[int](3),
 			4,
 		},
 		{
 			"slice does not contain matching values",
 			slice,
-			ValueGT(5),
+			ValueGT[int](5),
 			*new(int),
 		},
 	}
@@ -2307,19 +2307,19 @@ func TestSkip(t *testing.T) {
 }
 
 func TestSkipUntil(t *testing.T) {
-	alwaysTrueMatcher := func(_, _ any) bool { return true }
-	alwaysFalseMatcher := func(_, _ any) bool { return false }
+	alwaysTrueMatcher := func(_, _ int) bool { return true }
+	alwaysFalseMatcher := func(_, _ int) bool { return false }
 
 	testCases := []struct {
 		name     string
 		slice    []int
-		matcher  AnyMatcher
+		matcher  Matcher[int, int]
 		expected []int
 	}{
 		{
 			name:     "after 3",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueDeepEquals[any, any](3),
+			matcher:  ValueEquals[int](3),
 			expected: []int{3, 4, 5},
 		},
 		{
@@ -2358,19 +2358,19 @@ func TestSkipUntil(t *testing.T) {
 }
 
 func TestSkipWhile(t *testing.T) {
-	alwaysTrueMatcher := func(_, _ any) bool { return true }
-	alwaysFalseMatcher := func(_, _ any) bool { return false }
+	alwaysTrueMatcher := func(_, _ int) bool { return true }
+	alwaysFalseMatcher := func(_, _ int) bool { return false }
 
 	testCases := []struct {
 		name     string
 		slice    []int
-		matcher  AnyMatcher
+		matcher  Matcher[int, int]
 		expected []int
 	}{
 		{
 			name:     "skip while value is less than 3",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueLT(3),
+			matcher:  ValueLT[int](3),
 			expected: []int{3, 4, 5},
 		},
 		{
@@ -2969,37 +2969,37 @@ func TestTakeWhile(t *testing.T) {
 	testCases := []struct {
 		name     string
 		slice    []int
-		matcher  AnyMatcher
+		matcher  Matcher[int, int]
 		expected []int
 	}{
 		{
 			name:     "1 through 5 take while less than 3",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueLT(3),
+			matcher:  ValueLT[int](3),
 			expected: []int{1, 2},
 		},
 		{
 			name:     "1 through 5 take while less than 10",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueLT(10),
+			matcher:  ValueLT[int](10),
 			expected: []int{1, 2, 3, 4, 5},
 		},
 		{
 			name:     "1 through 5 take while less than 0",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueLT(0),
+			matcher:  ValueLT[int](0),
 			expected: []int{},
 		},
 		{
 			name:     "empty slice with matcher returning true",
 			slice:    []int{},
-			matcher:  func(_, _ any) bool { return true },
+			matcher:  func(_, _ int) bool { return true },
 			expected: []int{},
 		},
 		{
 			name:     "empty slice with matcher returning false",
 			slice:    []int{},
-			matcher:  func(_, _ any) bool { return false },
+			matcher:  func(_, _ int) bool { return false },
 			expected: []int{},
 		},
 	}
@@ -3017,37 +3017,37 @@ func TestTakeUntil(t *testing.T) {
 	testCases := []struct {
 		name     string
 		slice    []int
-		matcher  AnyMatcher
+		matcher  Matcher[int, int]
 		expected []int
 	}{
 		{
 			name:     "1 through 5 take until greater than 3",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueGT(3),
+			matcher:  ValueGT[int](3),
 			expected: []int{1, 2, 3},
 		},
 		{
 			name:     "1 through 5 take until less than 10",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueLT(10),
+			matcher:  ValueLT[int](10),
 			expected: []int{},
 		},
 		{
 			name:     "1 through 5 take until less than 0",
 			slice:    []int{1, 2, 3, 4, 5},
-			matcher:  ValueLT(0),
+			matcher:  ValueLT[int](0),
 			expected: []int{1, 2, 3, 4, 5},
 		},
 		{
 			name:     "empty slice with matcher returning true",
 			slice:    []int{},
-			matcher:  func(_, _ any) bool { return true },
+			matcher:  func(_, _ int) bool { return true },
 			expected: []int{},
 		},
 		{
 			name:     "empty slice with matcher returning false",
 			slice:    []int{},
-			matcher:  func(_, _ any) bool { return false },
+			matcher:  func(_, _ int) bool { return false },
 			expected: []int{},
 		},
 	}

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -160,7 +160,7 @@ func TestAnd(t *testing.T) {
 func TestAndValue(t *testing.T) {
 	i := 10
 
-	if !AndValue[int, int](
+	if !AndValue(
 		11,
 		func(v int) Matcher[int, int] { return ValueGT[int](-v) },
 		func(v int) Matcher[int, int] { return ValueLT[int](v) },
@@ -172,7 +172,7 @@ func TestAndValue(t *testing.T) {
 func TestOr(t *testing.T) {
 	i := 11
 
-	if !Or[int](ValueGT[int](9), ValueLT[int](10))(0, i) {
+	if !Or(ValueGT[int](9), ValueLT[int](10))(0, i) {
 		t.Error("11 is greater than 9 and 10")
 	}
 }
@@ -180,32 +180,32 @@ func TestOr(t *testing.T) {
 func TestOrReturningFalse(t *testing.T) {
 	i := 1
 
-	if Or[int](ValueGT[int](1), ValueLT[int](1))(0, i) {
+	if Or(ValueGT[int](1), ValueLT[int](1))(0, i) {
 		t.Error("1 is not less, nor greater than 1")
 	}
 }
 
 func TestOrValue(t *testing.T) {
-	i := 1
-
-	if OrValue[int](
-		1,
-		func(v int) Matcher[int, int] { return ValueGT[int](v) },
-		func(v int) Matcher[int, int] { return ValueLT[int](v) },
-	)(0, i) {
-		t.Error("1 is not less, nor greater than 1")
-	}
-}
-
-func TestOrValueReturningFalse(t *testing.T) {
 	i := 11
 
-	if OrValue[int](
+	if !OrValue(
 		10,
 		func(v int) Matcher[int, int] { return ValueGT[int](v) },
 		func(v int) Matcher[int, int] { return ValueLT[int](2 * v) },
 	)(0, i) {
 		t.Error("11 is greater than 10 and lesser than 20")
+	}
+}
+
+func TestOrValueReturningFalse(t *testing.T) {
+	i := 1
+
+	if OrValue(
+		1,
+		func(v int) Matcher[int, int] { return ValueGT[int](1) },
+		func(v int) Matcher[int, int] { return ValueLT[int](1) },
+	)(0, i) {
+		t.Error("1 is not less, nor greater than 1")
 	}
 }
 

--- a/matchers_test.go
+++ b/matchers_test.go
@@ -127,7 +127,7 @@ func TestFieldEquals(t *testing.T) {
 func TestFieldMatch(t *testing.T) {
 	u := user{Name: "Jon", Email: "jon@collections.go", Age: 33}
 
-	if !FieldMatch[user]("Age", ValueGT(30))(0, u) {
+	if !FieldMatch[user]("Age", ValueCastGT(30))(0, u) {
 		t.Error("user should've matched")
 	}
 }
@@ -144,7 +144,7 @@ func TestNot(t *testing.T) {
 func TestAnd(t *testing.T) {
 	i := 10
 
-	if !And[int](ValueGT(9), ValueLT(11))(0, i) {
+	if !And[int](ValueCastGT(9), ValueCastLT(11))(0, i) {
 		t.Error("10 is greater than 9 and lesser than 11")
 	}
 }
@@ -152,10 +152,10 @@ func TestAnd(t *testing.T) {
 func TestAndValue(t *testing.T) {
 	i := 10
 
-	if !AndValue(
+	if !AndValue[int, int](
 		11,
-		func(v int) AnyMatcher { return ValueGT(-v) },
-		func(v int) AnyMatcher { return ValueLT(v) },
+		func(v int) Matcher[int, int] { return ValueGT[int](-v) },
+		func(v int) Matcher[int, int] { return ValueLT[int](v) },
 	)(0, i) {
 		t.Error("10 is greater than -11 and lesser than 11")
 	}
@@ -164,7 +164,7 @@ func TestAndValue(t *testing.T) {
 func TestOr(t *testing.T) {
 	i := 11
 
-	if !Or[int](ValueGT(9), ValueLT(10))(0, i) {
+	if !Or[int](ValueGT[int](9), ValueLT[int](10))(0, i) {
 		t.Error("11 is greater than 9 and 10")
 	}
 }
@@ -172,10 +172,10 @@ func TestOr(t *testing.T) {
 func TestOrValue(t *testing.T) {
 	i := 11
 
-	if !OrValue(
+	if !OrValue[int](
 		10,
-		func(v int) AnyMatcher { return ValueGT(v) },
-		func(v int) AnyMatcher { return ValueLT(2 * v) },
+		func(v int) Matcher[int, int] { return ValueGT[int](v) },
+		func(v int) Matcher[int, int] { return ValueLT[int](2 * v) },
 	)(0, i) {
 		t.Error("11 is greater than 10 and lesser than 20")
 	}

--- a/support_test.go
+++ b/support_test.go
@@ -6,24 +6,14 @@ type user struct {
 	Age   int
 }
 
-func usernameMatch(u user) AnyMatcher {
-	return func(_, v any) bool {
-		collectionUser, ok := v.(user)
-		if !ok {
-			return false
-		}
-
-		return collectionUser.Name == u.Name
+func usernameMatch[K any](u user) Matcher[K, user] {
+	return func(_ K, v user) bool {
+		return v.Name == u.Name
 	}
 }
 
-func ageMatch(u user) AnyMatcher {
-	return func(_, v any) bool {
-		collectionUser, ok := v.(user)
-		if !ok {
-			return false
-		}
-
-		return collectionUser.Age == u.Age
+func ageMatch[K any](u user) Matcher[K, user] {
+	return func(_ K, v user) bool {
+		return v.Age == u.Age
 	}
 }

--- a/tests/benchmark/generic/first_where_test.go
+++ b/tests/benchmark/generic/first_where_test.go
@@ -1,0 +1,17 @@
+package generic
+
+import (
+	"testing"
+
+	. "github.com/thefuga/go-collections"
+	"github.com/thefuga/go-collections/tests/benchmark"
+)
+
+func BenchmarkFirstWhere(b *testing.B) {
+	slice := benchmark.BuildIntSlice()
+	half := len(slice) / 2
+
+	for n := 0; n < b.N; n++ {
+		FirstWhere(slice, ValueEquals[int](half))
+	}
+}

--- a/tests/benchmark/generic/skip_until_test.go
+++ b/tests/benchmark/generic/skip_until_test.go
@@ -10,7 +10,7 @@ import (
 func BenchmarkSkipUntil(b *testing.B) {
 	slice := benchmark.BuildIntSlice()
 	halfway := len(slice) / 2
-	matcher := func(i, _ any) bool { return i.(int) == halfway }
+	matcher := func(i, _ int) bool { return i == halfway }
 
 	for n := 0; n < b.N; n++ {
 		SkipUntil(slice, matcher)

--- a/tests/benchmark/generic/skip_while_test.go
+++ b/tests/benchmark/generic/skip_while_test.go
@@ -10,7 +10,7 @@ import (
 func BenchmarkSkipWhile(b *testing.B) {
 	slice := benchmark.BuildIntSlice()
 	halfway := len(slice) / 2
-	matcher := func(i, _ any) bool { return i.(int) == halfway }
+	matcher := func(i, _ int) bool { return i == halfway }
 
 	for n := 0; n < b.N; n++ {
 		SkipWhile(slice, matcher)

--- a/tests/benchmark/generic/take_until_test.go
+++ b/tests/benchmark/generic/take_until_test.go
@@ -9,7 +9,7 @@ import (
 
 func BenchmarkTakeUntil(b *testing.B) {
 	slice := benchmark.BuildIntSlice()
-	matcher := ValueGT(len(slice) / 2)
+	matcher := ValueGT[int](len(slice) / 2)
 
 	for n := 0; n < b.N; n++ {
 		TakeUntil(slice, matcher)

--- a/tests/benchmark/generic/take_while_test.go
+++ b/tests/benchmark/generic/take_while_test.go
@@ -9,7 +9,7 @@ import (
 
 func BenchmarkTakeWhile(b *testing.B) {
 	slice := benchmark.BuildIntSlice()
-	matcher := ValueLT(len(slice) / 2)
+	matcher := ValueLT[int](len(slice) / 2)
 
 	for n := 0; n < b.N; n++ {
 		TakeWhile(slice, matcher)


### PR DESCRIPTION
# What?
add type param to Matchers on generic functions
# Why?
because it makes them BLAZINGLY FAST™️
![Screenshot 2023-01-16 at 12 36 52 PM](https://user-images.githubusercontent.com/9938253/212715786-83430a87-147f-42f3-9a66-569a4ac022cc.png)
# How?
changing `AnyMatcher` to `Matcher[int, V]` and fixing tests
