### PR TITLE
feat(slice): add `Copy`

### DIFF
--- a/slice/collection.go
+++ b/slice/collection.go
@@ -17,6 +17,11 @@ func Collect[V any](values ...V) Collection[V] {
 	return values
 }
 
+// Copy returns a copy of this collection.
+func (c Collection[V]) Copy() Collection[V] {
+	return Collect(collections.Copy(c)...)
+}
+
 // Contains passes the collection and the given params to the generic Contains function.
 func (c Collection[V]) Contains(matcher collections.Matcher[int, V]) bool {
 	return collections.Contains(c, matcher)

--- a/slice/collection_test.go
+++ b/slice/collection_test.go
@@ -544,12 +544,12 @@ func TestCopy(t *testing.T) {
 			Collection[int]{},
 		},
 		{
-			"does not change collection with a single element",
+			"does not change a collection with a single element",
 			Collection[int]{1},
 			Collection[int]{1},
 		},
 		{
-			"does not change collection with 100 elements",
+			"does not change a collection with 100 elements",
 			Collect(collections.Range(1, 100)...),
 			Collect(collections.Range(1, 100)...),
 		},
@@ -561,6 +561,19 @@ func TestCopy(t *testing.T) {
 				t.Errorf("expected  %v, got %v", got, got)
 			}
 		})
+	}
+}
+
+func TestChangingACopyDoesNotChangeTheOriginal(t *testing.T) {
+	coll := Collect(3, 2, 1)
+	collCopy := coll.Copy()
+	expected := Collect(3, 2, 1)
+
+	// mutate coll
+	coll.Sort(func(a, b int) bool { return a < b })
+
+	if !reflect.DeepEqual(collCopy, expected) {
+		t.Errorf("expected %v, got %v", expected, collCopy)
 	}
 }
 

--- a/slice/collection_test.go
+++ b/slice/collection_test.go
@@ -532,6 +532,38 @@ func TestIsEmpty(t *testing.T) {
 	}
 }
 
+func TestCopy(t *testing.T) {
+	testCases := []struct {
+		description string
+		collection  Collection[int]
+		expected    Collection[int]
+	}{
+		{
+			"does not change empty collection",
+			Collection[int]{},
+			Collection[int]{},
+		},
+		{
+			"does not change collection with a single element",
+			Collection[int]{1},
+			Collection[int]{1},
+		},
+		{
+			"does not change collection with 100 elements",
+			Collect(collections.Range(1, 100)...),
+			Collect(collections.Range(1, 100)...),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if got := tc.collection.Copy(); !reflect.DeepEqual(got, tc.expected) {
+				t.Errorf("expected  %v, got %v", got, got)
+			}
+		})
+	}
+}
+
 func TestContains(t *testing.T) {
 	testCases := []struct {
 		description string

--- a/tests/benchmark/slice/slice_test.go
+++ b/tests/benchmark/slice/slice_test.go
@@ -22,6 +22,12 @@ func buildIntSlice(n int) []int {
 	return result
 }
 
+func BenchmarkSliceCollectionCopy(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		sliceCollection = sliceCollection.Copy()
+	}
+}
+
 func BenchmarkSliceCollectionPush(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		sliceCollection = sliceCollection.Push(n)


### PR DESCRIPTION
# What?
add function to copy a slice collection

# Why?
I was implementing `Reverse` for the slice collection and I found myself needing it

# How?
using the generic version and collecting the result
